### PR TITLE
Expose data and params kwargs for request helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
+**/*.pyc
 *.py[cod]
 *$py.class
 

--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __author__ = "WorkOS"
 

--- a/workos/audit_trail.py
+++ b/workos/audit_trail.py
@@ -62,7 +62,7 @@ class AuditTrail(object):
         return self.request_helper.request(
             EVENTS_PATH,
             method=REQUEST_METHOD_POST,
-            params=event,
+            data=event,
             headers=headers,
             token=workos.api_key,
         )

--- a/workos/utils/request.py
+++ b/workos/utils/request.py
@@ -34,7 +34,13 @@ class RequestHelper(object):
         return self.base_api_url.format(path)
 
     def request(
-        self, path, method=REQUEST_METHOD_GET, params=None, headers=None, token=None
+        self,
+        path,
+        method=REQUEST_METHOD_GET,
+        data=None,
+        params=None,
+        headers=None,
+        token=None,
     ):
         """Executes a request against the WorkOS API.
 
@@ -58,11 +64,9 @@ class RequestHelper(object):
         headers.update(BASE_HEADERS)
         url = self.generate_api_url(path)
 
-        request_fn = getattr(requests, method)
-        if method == REQUEST_METHOD_GET:
-            response = request_fn(url, headers=headers, params=params)
-        else:
-            response = request_fn(url, headers=headers, data=params)
+        response = getattr(requests, method)(
+            url, headers=headers, data=data, params=params
+        )
 
         status_code = response.status_code
         if status_code >= 400 and status_code < 500:


### PR DESCRIPTION
# Overview
Expose data and params for the request helper as pass through kwargs. This'd allow to make the oauth post call with query params. Straightforward abstraction that I hope doesn't cause much confusion in the future.