### PR TITLE
Move OAuth Post query params to form data

### DIFF
--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __author__ = "WorkOS"
 

--- a/workos/audit_trail.py
+++ b/workos/audit_trail.py
@@ -62,7 +62,7 @@ class AuditTrail(object):
         return self.request_helper.request(
             EVENTS_PATH,
             method=REQUEST_METHOD_POST,
-            data=event,
+            params=event,
             headers=headers,
             token=workos.api_key,
         )

--- a/workos/utils/request.py
+++ b/workos/utils/request.py
@@ -34,13 +34,7 @@ class RequestHelper(object):
         return self.base_api_url.format(path)
 
     def request(
-        self,
-        path,
-        method=REQUEST_METHOD_GET,
-        data=None,
-        params=None,
-        headers=None,
-        token=None,
+        self, path, method=REQUEST_METHOD_GET, params=None, headers=None, token=None,
     ):
         """Executes a request against the WorkOS API.
 
@@ -64,9 +58,11 @@ class RequestHelper(object):
         headers.update(BASE_HEADERS)
         url = self.generate_api_url(path)
 
-        response = getattr(requests, method)(
-            url, headers=headers, data=data, params=params
-        )
+        request_fn = getattr(requests, method)
+        if method == REQUEST_METHOD_GET:
+            response = request_fn(url, headers=headers, params=params)
+        else:
+            response = request_fn(url, headers=headers, data=params)
 
         status_code = response.status_code
         if status_code >= 400 and status_code < 500:


### PR DESCRIPTION
# Overview
Getting a Profile as apart of the OAuth flow will now support having the bits passed over as form data.

Here's how my request to my local server looks with this change:
```
[api] [1584560790651] INFO  (32020 on henrys-mbp.lan): request completed
[api]     req: {
[api]       "id": 40,
[api]       "method": "POST",
[api]       "url": "/sso/token",
[api]       "headers": {
[api]         "host": "localhost:7000",
[api]         "user-agent": "WorkOS Python/0.2.2",
[api]         "accept-encoding": "gzip, deflate",
[api]         "accept": "*/*",
[api]         "connection": "keep-alive",
[api]         "content-length": "126",
[api]         "content-type": "application/x-www-form-urlencoded"
[api]       },
[api]       "body": {
[api]         "client_id": "dominos",
[api]         "client_secret": "pizzas",
[api]         "code": "abc",
[api]         "grant_type": "authorization_code"
[api]       }
[api]     }
[api]     res: {
[api]       "statusCode": 400,
[api]       "headers": {
[api]         "vary": "Origin, Accept-Encoding",
[api]         "access-control-allow-credentials": "true",
[api]         "x-dns-prefetch-control": "off",
[api]         "x-frame-options": "SAMEORIGIN",
[api]         "strict-transport-security": "max-age=15552000; includeSubDomains",
[api]         "x-download-options": "noopen",
[api]         "x-content-type-options": "nosniff",
[api]         "x-xss-protection": "1; mode=block",
[api]         "x-request-id": "",
[api]         "content-type": "application/json; charset=utf-8",
[api]         "content-length": "55",
[api]         "etag": "W/\"37-AytkoiMEzU7kC6iEJGgl4mQYp+4\""
[api]       }
[api]     }
[api]     responseTime: 31
```