### PR TITLE
Add Directory Sync API and fix Audit Trail naming

### DIFF
--- a/tests/test_audit_trail.py
+++ b/tests/test_audit_trail.py
@@ -8,7 +8,7 @@ import workos
 from workos.audit_trail import AuditTrail
 
 
-class TestSSO(object):
+class TestAuditTrail(object):
     @pytest.fixture(autouse=True)
     def setup(self, set_api_key_and_project_id):
         self.audit_trail = AuditTrail()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,14 +7,18 @@ from workos.exceptions import ConfigurationException
 class TestClient(object):
     @pytest.fixture(autouse=True)
     def setup(self):
-        client._sso = None
         client._audit_trail = None
+        client._directory_sync = None
+        client._sso = None
 
     def test_initialize_sso(self, set_api_key_and_project_id):
         assert bool(client.sso)
 
     def test_initialize_audit_log(self, set_api_key_and_project_id):
         assert bool(client.audit_trail)
+
+    def test_initialize_directory_sync(self, set_api_key):
+        assert bool(client.directory_sync)
 
     def test_initialize_sso_missing_api_key(self, set_project_id):
         with pytest.raises(ConfigurationException) as ex:
@@ -45,6 +49,14 @@ class TestClient(object):
     def test_initialize_audit_trail_missing_api_key(self):
         with pytest.raises(ConfigurationException) as ex:
             client.audit_trail
+
+        message = str(ex)
+
+        assert "api_key" in message
+
+    def test_initialize_directory_sync_missing_api_key(self):
+        with pytest.raises(ConfigurationException) as ex:
+            client.directory_sync
 
         message = str(ex)
 

--- a/tests/test_directory_sync.py
+++ b/tests/test_directory_sync.py
@@ -1,0 +1,135 @@
+import json
+from requests import Response
+
+import pytest
+
+import workos
+from workos.directory_sync import DirectorySync
+from workos.utils.request import RESPONSE_TYPE_CODE
+
+
+class TestSSO(object):
+    @pytest.fixture(autouse=True)
+    def setup(self, set_api_key):
+        self.directory_sync = DirectorySync()
+
+    @pytest.fixture
+    def mock_directory_users(self):
+        return {
+            "listMetadata": {"before": None, "after": None},
+            "data": [
+                {
+                    "username": "yoon@seri.com",
+                    "last_name": "Seri",
+                    "first_name": "Yoon",
+                    "emails": [
+                        {"primary": True, "type": "work", "value": "yoon@seri.com"}
+                    ],
+                    "raw_attributes": {
+                        "schemas": ["urn:scim:schemas:core:1.0"],
+                        "name": {"familyName": "Seri", "givenName": "Yoon"},
+                        "externalId": "external-id",
+                        "locale": "en_US",
+                        "userName": "yoon@seri.com",
+                        "id": "directory_usr_id",
+                        "displayName": "Yoon Seri",
+                        "active": True,
+                        "groups": [],
+                        "meta": {
+                            "created": "2020-02-21T00:32:14.443Z",
+                            "version": "7ff066f75718e21a521c269ae7eafce474ae07c1",
+                            "lastModified": "2020-02-21T00:36:44.638Z",
+                        },
+                        "emails": [
+                            {"value": "yoon@seri.com", "type": "work", "primary": True}
+                        ],
+                    },
+                    "id": "directory_usr_id",
+                }
+            ],
+        }
+
+    @pytest.fixture
+    def mock_directory_groups(self):
+        return {
+            "data": [{"name": "Developers", "id": "directory_grp_id"}],
+            "listMetadata": {
+                "before": "directory_grp_id",
+                "after": "directory_grp_id",
+            },
+        }
+
+    @pytest.fixture
+    def mock_directory_user(self):
+        return {
+            "username": "yoon@seri.com",
+            "last_name": "Seri",
+            "first_name": "Yoon",
+            "emails": [{"primary": True, "type": "work", "value": "yoon@seri.com"}],
+            "raw_attributes": {
+                "schemas": ["urn:scim:schemas:core:1.0"],
+                "name": {"familyName": "Seri", "givenName": "Yoon"},
+                "externalId": "external-id",
+                "locale": "en_US",
+                "userName": "yoon@seri.com",
+                "id": "directory_usr_id",
+                "displayName": "Yoon Seri",
+                "active": True,
+                "groups": [],
+                "meta": {
+                    "created": "2020-02-21T00:32:14.443Z",
+                    "version": "7ff066f75718e21a521c269ae7eafce474ae07c1",
+                    "lastModified": "2020-02-21T00:36:44.638Z",
+                },
+                "emails": [{"value": "yoon@seri.com", "type": "work", "primary": True}],
+            },
+            "id": "directory_usr_id",
+        }
+
+    def test_get_directory_users(self, mock_directory_users, mock_request_method):
+        mock_response = Response()
+        mock_response.status_code = 200
+        mock_response.response_dict = mock_directory_users
+        mock_request_method("get", mock_response, 200)
+        response = self.directory_sync.get_directory_users(
+            directory_endpoint_id="directory_edp_id"
+        )
+        assert response.status_code == 200
+        assert response.response_dict == mock_directory_users
+
+    def test_get_directory_groups(self, mock_directory_groups, mock_request_method):
+        mock_response = Response()
+        mock_response.status_code = 200
+        mock_response.response_dict = mock_directory_groups
+        mock_request_method("get", mock_response, 200)
+        response = self.directory_sync.get_directory_groups(
+            directory_endpoint_id="directory_edp_id"
+        )
+        assert response.status_code == 200
+        assert response.response_dict == mock_directory_groups
+
+    def test_get_directory_user(self, mock_directory_user, mock_request_method):
+        mock_response = Response()
+        mock_response.status_code = 200
+        mock_response.response_dict = mock_directory_user
+        mock_request_method("get", mock_response, 200)
+        response = self.directory_sync.get_directory_user(
+            directory_endpoint_id="directory_edp_id",
+            directory_user_id="directory_usr_id",
+        )
+        assert response.status_code == 200
+        assert response.response_dict == mock_directory_user
+
+    def test_get_directory_user_groups(
+        self, mock_directory_groups, mock_request_method
+    ):
+        mock_response = Response()
+        mock_response.status_code = 200
+        mock_response.response_dict = mock_directory_groups
+        mock_request_method("get", mock_response, 200)
+        response = self.directory_sync.get_directory_user_groups(
+            directory_endpoint_id="directory_edp_id",
+            directory_user_id="directory_usr_id",
+        )
+        assert response.status_code == 200
+        assert response.response_dict == mock_directory_groups

--- a/workos/client.py
+++ b/workos/client.py
@@ -1,4 +1,5 @@
 from workos.audit_trail import AuditTrail
+from workos.directory_sync import DirectorySync
 from workos.sso import SSO
 
 
@@ -16,6 +17,12 @@ class Client(object):
         if not getattr(self, "_audit_trail", None):
             self._audit_trail = AuditTrail()
         return self._audit_trail
+
+    @property
+    def directory_sync(self):
+        if not getattr(self, "_directory_sync", None):
+            self._directory_sync = DirectorySync()
+        return self._directory_sync
 
 
 client = Client()

--- a/workos/directory_sync.py
+++ b/workos/directory_sync.py
@@ -21,16 +21,16 @@ class DirectorySync(object):
     def get_directory_users(
         self, directory_endpoint_id, limit=RESPONSE_LIMIT, before=None, after=None
     ):
-        """Gets a list of provisioned users for a directory endpoint.
+        """Gets a list of provisioned Users for a Directory Endpoint.
 
         Args:
             directory_endpoint_id (str): Directory Endpoint unique identifier.
             limit (int): Maximum number of records to return.
-            before (str): Pagination cursor to receive records before a provided directory endpoint id.
-            after (str): Pagination cursor to receive records after a provided directory endpoint id.
+            before (str): Pagination cursor to receive records before a provided Directory Endpoint ID.
+            after (str): Pagination cursor to receive records after a provided Directory Endpoint ID.
 
         Returns:
-            dict: Directory users response from WorkOS.
+            dict: Directory Users response from WorkOS.
         """
         params = {"limit": limit, "before": before, "after": after}
         return self.request_helper.request(
@@ -45,16 +45,16 @@ class DirectorySync(object):
     def get_directory_groups(
         self, directory_endpoint_id, limit=RESPONSE_LIMIT, before=None, after=None
     ):
-        """Gets a list of provisioned groups for a directory endpoint.
+        """Gets a list of provisioned Groups for a Directory Endpoint.
 
         Args:
             directory_endpoint_id (str): Directory Endpoint unique identifier.
             limit (int): Maximum number of records to return.
-            before (str): Pagination cursor to receive records before a provided directory endpoint id.
-            after (str): Pagination cursor to receive records after a provided directory endpoint id.
+            before (str): Pagination cursor to receive records before a provided Directory Endpoint ID.
+            after (str): Pagination cursor to receive records after a provided Directory Endpoint ID.
 
         Returns:
-            dict: Directory groups response from WorkOS.
+            dict: Directory Groups response from WorkOS.
         """
         params = {"limit": limit, "before": before, "after": after}
         return self.request_helper.request(
@@ -71,7 +71,7 @@ class DirectorySync(object):
 
         Args:
             directory_endpoint_id (str): Directory Endpoint unique identifier.
-            directory_user_id(str): Directory User unique identifier.
+            directory_user_id (str): Directory User unique identifier.
 
         Returns:
             dict: Directory user response from WorkOS.
@@ -90,10 +90,10 @@ class DirectorySync(object):
 
         Args:
             directory_endpoint_id (str): Directory Endpoint unique identifier.
-            directory_user_id(str): Directory User unique identifier.
+            directory_user_id (str): Directory User unique identifier.
 
         Returns:
-            dict: Directory user's groups response from WorkOS.
+            dict: Directory User's Groups response from WorkOS.
         """
         return self.request_helper.request(
             "directories/{directory_endpoint_id}/users/{directory_user_id}/groups".format(

--- a/workos/directory_sync.py
+++ b/workos/directory_sync.py
@@ -1,0 +1,65 @@
+import workos
+from workos.utils.request import RequestHelper, REQUEST_METHOD_GET
+from workos.utils.validation import DIRECTORY_SYNC_MODULE, validate_settings
+
+RESPONSE_LIMIT = 10
+
+
+class DirectorySync(object):
+    """Offers methods through the WorkOS Directory Sync service."""
+
+    @validate_settings(DIRECTORY_SYNC_MODULE)
+    def __init__(self):
+        pass
+
+    @property
+    def request_helper(self):
+        if not getattr(self, "_request_helper", None):
+            self._request_helper = RequestHelper()
+        return self._request_helper
+
+    def get_directory_users(
+        self, directory_endpoint_id, limit=RESPONSE_LIMIT, before=None, after=None
+    ):
+        params = {"limit": limit, "before": before, "after": after}
+        return self.request_helper.request(
+            "directories/{directory_endpoint_id}/users".format(
+                directory_endpoint_id=directory_endpoint_id
+            ),
+            method=REQUEST_METHOD_GET,
+            params=params,
+            token=workos.api_key,
+        )
+
+    def get_directory_groups(
+        self, directory_endpoint_id, limit=RESPONSE_LIMIT, before=None, after=None
+    ):
+        params = {"limit": limit, "before": before, "after": after}
+        return self.request_helper.request(
+            "directories/{directory_endpoint_id}/groups".format(
+                directory_endpoint_id=directory_endpoint_id
+            ),
+            method=REQUEST_METHOD_GET,
+            params=params,
+            token=workos.api_key,
+        )
+
+    def get_directory_user(self, directory_endpoint_id, directory_user_id):
+        return self.request_helper.request(
+            "directories/{directory_endpoint_id}/users/{directory_user_id}".format(
+                directory_endpoint_id=directory_endpoint_id,
+                directory_user_id=directory_user_id,
+            ),
+            method=REQUEST_METHOD_GET,
+            token=workos.api_key,
+        )
+
+    def get_directory_user_groups(self, directory_endpoint_id, directory_user_id):
+        return self.request_helper.request(
+            "directories/{directory_endpoint_id}/users/{directory_user_id}/groups".format(
+                directory_endpoint_id=directory_endpoint_id,
+                directory_user_id=directory_user_id,
+            ),
+            method=REQUEST_METHOD_GET,
+            token=workos.api_key,
+        )

--- a/workos/directory_sync.py
+++ b/workos/directory_sync.py
@@ -21,6 +21,17 @@ class DirectorySync(object):
     def get_directory_users(
         self, directory_endpoint_id, limit=RESPONSE_LIMIT, before=None, after=None
     ):
+        """Gets a list of provisioned users for a directory endpoint.
+
+        Args:
+            directory_endpoint_id (str): Directory Endpoint unique identifier.
+            limit (int): Maximum number of records to return.
+            before (str): Pagination cursor to receive records before a provided directory endpoint id.
+            after (str): Pagination cursor to receive records after a provided directory endpoint id.
+
+        Returns:
+            dict: Directory users response from WorkOS.
+        """
         params = {"limit": limit, "before": before, "after": after}
         return self.request_helper.request(
             "directories/{directory_endpoint_id}/users".format(
@@ -34,6 +45,17 @@ class DirectorySync(object):
     def get_directory_groups(
         self, directory_endpoint_id, limit=RESPONSE_LIMIT, before=None, after=None
     ):
+        """Gets a list of provisioned groups for a directory endpoint.
+
+        Args:
+            directory_endpoint_id (str): Directory Endpoint unique identifier.
+            limit (int): Maximum number of records to return.
+            before (str): Pagination cursor to receive records before a provided directory endpoint id.
+            after (str): Pagination cursor to receive records after a provided directory endpoint id.
+
+        Returns:
+            dict: Directory groups response from WorkOS.
+        """
         params = {"limit": limit, "before": before, "after": after}
         return self.request_helper.request(
             "directories/{directory_endpoint_id}/groups".format(
@@ -45,6 +67,15 @@ class DirectorySync(object):
         )
 
     def get_directory_user(self, directory_endpoint_id, directory_user_id):
+        """Gets details for a single provisioned directory user.
+
+        Args:
+            directory_endpoint_id (str): Directory Endpoint unique identifier.
+            directory_user_id(str): Directory User unique identifier.
+
+        Returns:
+            dict: Directory user response from WorkOS.
+        """
         return self.request_helper.request(
             "directories/{directory_endpoint_id}/users/{directory_user_id}".format(
                 directory_endpoint_id=directory_endpoint_id,
@@ -55,6 +86,15 @@ class DirectorySync(object):
         )
 
     def get_directory_user_groups(self, directory_endpoint_id, directory_user_id):
+        """Gets details for a directory user's provisioned groups.
+
+        Args:
+            directory_endpoint_id (str): Directory Endpoint unique identifier.
+            directory_user_id(str): Directory User unique identifier.
+
+        Returns:
+            dict: Directory user's groups response from WorkOS.
+        """
         return self.request_helper.request(
             "directories/{directory_endpoint_id}/users/{directory_user_id}/groups".format(
                 directory_endpoint_id=directory_endpoint_id,

--- a/workos/utils/validation.py
+++ b/workos/utils/validation.py
@@ -4,10 +4,12 @@ import workos
 from workos.exceptions import ConfigurationException
 
 AUDIT_TRAIL_MODULE = "AuditTrail"
+DIRECTORY_SYNC_MODULE = "DirectorySync"
 SSO_MODULE = "SSO"
 
 REQUIRED_SETTINGS_FOR_MODULE = {
     AUDIT_TRAIL_MODULE: ["api_key",],
+    DIRECTORY_SYNC_MODULE: ["api_key",],
     SSO_MODULE: ["api_key", "project_id",],
 }
 


### PR DESCRIPTION
Add Python wrappers for the API reference endpoints [here](https://docs.workos.com/directory-sync/api-reference).