### PR TITLE
Fix enum to string conversion in `get_authorization_url`

### DIFF
--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -80,7 +80,7 @@ class TestSSO(object):
         parsed_url = urlparse(authorization_url)
 
         assert dict(parse_qsl(parsed_url.query)) == {
-            "provider": str(self.provider),
+            "provider": str(self.provider.value),
             "client_id": workos.project_id,
             "redirect_uri": self.redirect_uri,
             "response_type": RESPONSE_TYPE_CODE,
@@ -116,7 +116,7 @@ class TestSSO(object):
 
         assert dict(parse_qsl(parsed_url.query)) == {
             "domain": self.customer_domain,
-            "provider": str(self.provider),
+            "provider": str(self.provider.value),
             "client_id": workos.project_id,
             "redirect_uri": self.redirect_uri,
             "response_type": RESPONSE_TYPE_CODE,

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -44,7 +44,7 @@ class SSO(object):
             redirect_uri (str) - A valid redirect URI, as specified on WorkOS
             state (dict) - A dict passed to WorkOS, that'd be preserved through the authentication workflow, passed
             back as a query parameter
-            provider (str) - Authentication service provider descriptor
+            provider (ConnectionType) - Authentication service provider descriptor
 
         Returns:
             str: URL to redirect a User to to begin the OAuth workflow with WorkOS
@@ -62,7 +62,7 @@ class SSO(object):
         if provider is not None:
             if not isinstance(provider, ConnectionType):
                 raise ValueError("'provider' must be of type ConnectionType")
-            params["provider"] = str(provider)
+            params["provider"] = str(provider.value)
         if domain is not None:
             params["domain"] = domain
 


### PR DESCRIPTION
* Update method documentation to indicate `provider` is a `ConnectionType`
* Convert enum value for Authorization URL