### PR TITLE
Install enum34 only on Python < 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ setup(
     packages=find_packages(exclude=["tests*",]),
     zip_safe=False,
     license=about["__license__"],
-    install_requires=["enum34>=1.1.10", "requests>=2.22.0"],
-    extras_require={"dev": dev_requirements,},
+    install_requires=["requests>=2.22.0"],
+    extras_require={"dev": dev_requirements, ":python_version<'3.4'": ["enum34"],},
     classifiers=[
         "Development Status :: 1 - Planning",
         "Intended Audience :: Developers",

--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 __author__ = "WorkOS"
 


### PR DESCRIPTION
Install enum34 only on Python < 3.4 where it does not exist.