### PR TITLE
Fix get_events filtering

### DIFF
--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 __author__ = "WorkOS"
 

--- a/workos/audit_trail.py
+++ b/workos/audit_trail.py
@@ -126,25 +126,25 @@ class AuditTrail(object):
         }
 
         if group is not None:
-            params["group"] = group
+            params["group[]"] = group
 
         if action is not None:
-            params["action"] = action
+            params["action[]"] = action
 
         if action_type is not None:
-            params["action_type"] = action_type
+            params["action_type[]"] = action_type
 
         if actor_name is not None:
-            params["actor_name"] = actor_name
+            params["actor_name[]"] = actor_name
 
         if actor_id is not None:
-            params["actor_id"] = actor_id
+            params["actor_id[]"] = actor_id
 
         if target_name is not None:
-            params["target_name"] = target_name
+            params["target_name[]"] = target_name
 
         if target_id is not None:
-            params["target_id"] = target_id
+            params["target_id[]"] = target_id
 
         if occurred_at is not None:
             params["occurred_at"] = occurred_at

--- a/workos/audit_trail.py
+++ b/workos/audit_trail.py
@@ -126,25 +126,25 @@ class AuditTrail(object):
         }
 
         if group is not None:
-            params["group"] = list(group)
+            params["group"] = group
 
         if action is not None:
-            params["action"] = list(action)
+            params["action"] = action
 
         if action_type is not None:
-            params["action_type"] = list(action_type)
+            params["action_type"] = action_type
 
         if actor_name is not None:
-            params["actor_name"] = list(actor_name)
+            params["actor_name"] = actor_name
 
         if actor_id is not None:
-            params["actor_id"] = list(actor_id)
+            params["actor_id"] = actor_id
 
         if target_name is not None:
-            params["target_name"] = list(target_name)
+            params["target_name"] = target_name
 
         if target_id is not None:
-            params["target_id"] = list(target_id)
+            params["target_id"] = target_id
 
         if occurred_at is not None:
             params["occurred_at"] = occurred_at


### PR DESCRIPTION
Don't actually need to wrap the input in `list()`... it would actually break things in this case as it turns out something like `list('abc')` results in `['a', 'b', 'c']`.

For requests, we can actually pass in the input as is because a string and a single element array are represented the same way by python requests. `'foo'` and `['foo']` would be transformed into `/events?group=foo`.