### PR TITLE
Remove restriction on before and after params for get events

### DIFF
--- a/tests/test_audit_trail.py
+++ b/tests/test_audit_trail.py
@@ -80,10 +80,6 @@ class TestAuditTrail(object):
         events, before, after = self.audit_trail.get_events()
         assert events[0].to_dict() == event
 
-    def test_get_events_raises_valueerror_when_before_and_after_provided(self):
-        with pytest.raises(ValueError):
-            self.audit_trail.get_events(before="evt_123", after="evt_456")
-
     def test_get_events_correctly_includes_occured_at_filter(
         self, capture_and_mock_request
     ):

--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 __author__ = "WorkOS"
 

--- a/workos/audit_trail.py
+++ b/workos/audit_trail.py
@@ -116,9 +116,6 @@ class AuditTrail(object):
                 string - Event ID to use as before cursor
                 string - Event ID to use as after cursor
         """
-        if before and after:
-            raise ValueError("Specify either before or after")
-
         params = {
             "before": before,
             "after": after,


### PR DESCRIPTION
Misinterpreted how the filters were being used App side. Direction is determined by before and after. Beyond that, both params will also be used in filtering so we shouldn't restrict both of them being used.