### PR TITLE
Add MagicLink support through passwordless module

### DIFF
--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -19,10 +19,12 @@ class TestPasswordless(object):
             "email": "demo@workos-okta.com",
             "expires_at": "2020-08-13T05:50:00.000Z",
             "link": "https://auth.workos.com/passwordless/4TeRexuejWCKs9rrFOIuLRYEr/confirm",
-            "object": "passwordless_session"
+            "object": "passwordless_session",
         }
 
-    def test_create_session_succeeds(self, mock_passwordless_session, mock_request_method):
+    def test_create_session_succeeds(
+        self, mock_passwordless_session, mock_request_method
+    ):
         mock_response = Response()
         mock_response.status_code = 201
         mock_response.response_dict = mock_passwordless_session
@@ -38,7 +40,6 @@ class TestPasswordless(object):
         assert response.response_dict == mock_passwordless_session
 
     def test_get_send_session_succeeds(self, mock_request_method):
-
         response = {
             "success": True,
         }

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -1,0 +1,50 @@
+import json
+from requests import Response
+
+import pytest
+
+import workos
+from workos.passwordless import Passwordless
+
+
+class TestPasswordless(object):
+    @pytest.fixture(autouse=True)
+    def setup(self, set_api_key_and_project_id):
+        self.passwordless = Passwordless()
+
+    @pytest.fixture
+    def mock_passwordless_session(self):
+        return {
+          "id": "passwordless_session_01EHDAK2BFGWCSZXP9HGZ3VK8C",
+          "email": "demo@workos-okta.com",
+          "expires_at": "2020-08-13T05:50:00.000Z",
+          "link": "https://auth.workos.com/passwordless/4TeRexuejWCKs9rrFOIuLRYEr/confirm",
+          "object": "passwordless_session"
+        }
+
+    def test_create_session_succeeds(self, mock_passwordless_session, mock_request_method):
+        mock_response = Response()
+        mock_response.status_code = 201
+        mock_response.response_dict = mock_passwordless_session
+        mock_request_method("post", mock_response, 201)
+
+        session_options = {
+            "email": "demo@workos-okta.com",
+            "session_type": "MagicLink",
+        }
+        response = self.passwordless.create_session(session_options)
+
+        assert response.status_code == 201
+        assert response.response_dict == mock_passwordless_session
+
+    def test_get_send_session_succeeds(self, mock_request_method):
+
+        response = {
+            "success": True,
+        }
+        mock_request_method("post", response, 200)
+
+        response = self.passwordless.send_session(
+          "passwordless_session_01EHDAK2BFGWCSZXP9HGZ3VK8C"
+        )
+        assert response["success"] == True

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -15,11 +15,11 @@ class TestPasswordless(object):
     @pytest.fixture
     def mock_passwordless_session(self):
         return {
-          "id": "passwordless_session_01EHDAK2BFGWCSZXP9HGZ3VK8C",
-          "email": "demo@workos-okta.com",
-          "expires_at": "2020-08-13T05:50:00.000Z",
-          "link": "https://auth.workos.com/passwordless/4TeRexuejWCKs9rrFOIuLRYEr/confirm",
-          "object": "passwordless_session"
+            "id": "passwordless_session_01EHDAK2BFGWCSZXP9HGZ3VK8C",
+            "email": "demo@workos-okta.com",
+            "expires_at": "2020-08-13T05:50:00.000Z",
+            "link": "https://auth.workos.com/passwordless/4TeRexuejWCKs9rrFOIuLRYEr/confirm",
+            "object": "passwordless_session"
         }
 
     def test_create_session_succeeds(self, mock_passwordless_session, mock_request_method):
@@ -45,6 +45,6 @@ class TestPasswordless(object):
         mock_request_method("post", response, 200)
 
         response = self.passwordless.send_session(
-          "passwordless_session_01EHDAK2BFGWCSZXP9HGZ3VK8C"
+            "passwordless_session_01EHDAK2BFGWCSZXP9HGZ3VK8C"
         )
         assert response["success"] == True

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -48,4 +48,4 @@ class TestPasswordless(object):
         response = self.passwordless.send_session(
             "passwordless_session_01EHDAK2BFGWCSZXP9HGZ3VK8C"
         )
-        assert response["success"] == True
+        assert response == True

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -32,7 +32,7 @@ class TestPasswordless(object):
 
         session_options = {
             "email": "demo@workos-okta.com",
-            "session_type": "MagicLink",
+            "type": "MagicLink",
         }
         response = self.passwordless.create_session(session_options)
 

--- a/workos/passwordless.py
+++ b/workos/passwordless.py
@@ -1,0 +1,59 @@
+import workos
+from workos.utils.request import RequestHelper, REQUEST_METHOD_POST
+from workos.utils.validation import PASSWORDLESS_MODULE, validate_settings
+
+
+class Passwordless(object):
+    """Offers methods through the WorkOS Passwordless service."""
+
+    @validate_settings(PASSWORDLESS_MODULE)
+    def __init__(self):
+        pass
+
+    @property
+    def request_helper(self):
+        if not getattr(self, "_request_helper", None):
+            self._request_helper = RequestHelper()
+        return self._request_helper
+
+    def create_session(self, session_options):
+        """Create an Passwordless Session.
+
+        Args:
+            session_options (dict) - An session options object
+                session_options[email] (str): The email of the user to authenticate.
+                session_options[state] (str): Optional parameter that the redirect
+                    URI received from WorkOS will contain. The state parameter
+                    can be used to encode arbitrary information to help
+                    restore application state between redirects.
+                session_options[type] (str): The type of Passwordless Session to
+                    create. Currently, the only supported value is 'MagicLink'.
+
+        Returns:
+            dict: Passwordless Session
+        """
+
+        return self.request_helper.request(
+            "passwordless/sessions",
+            method=REQUEST_METHOD_POST,
+            params=session_options,
+            token=workos.api_key,
+        )
+
+    def send_session(self, session_id):
+        """Send a Passwordless Session via email.
+
+        Note, either 'directory' or 'user' must be provided.
+
+        Args:
+            session_id (str): The unique identifier of the Passwordless
+      				Session to send an email for.
+
+        Returns:
+            dict: {"success": true} if successful
+        """
+        return self.request_helper.request(
+            "passwordless/sessions/{session_id}/send",
+            method=REQUEST_METHOD_POST,
+            token=workos.api_key,
+        )

--- a/workos/passwordless.py
+++ b/workos/passwordless.py
@@ -43,8 +43,6 @@ class Passwordless(object):
     def send_session(self, session_id):
         """Send a Passwordless Session via email.
 
-        Note, either 'directory' or 'user' must be provided.
-
         Args:
             session_id (str): The unique identifier of the Passwordless
       				Session to send an email for.
@@ -52,8 +50,10 @@ class Passwordless(object):
         Returns:
             dict: {"success": true} if successful
         """
-        return self.request_helper.request(
+        self.request_helper.request(
             "passwordless/sessions/{session_id}/send".format(session_id=session_id),
             method=REQUEST_METHOD_POST,
             token=workos.api_key,
         )
+
+        return True

--- a/workos/passwordless.py
+++ b/workos/passwordless.py
@@ -53,7 +53,7 @@ class Passwordless(object):
             dict: {"success": true} if successful
         """
         return self.request_helper.request(
-            "passwordless/sessions/{session_id}/send",
+            "passwordless/sessions/{session_id}/send".format(session_id=session_id),
             method=REQUEST_METHOD_POST,
             token=workos.api_key,
         )

--- a/workos/passwordless.py
+++ b/workos/passwordless.py
@@ -17,7 +17,7 @@ class Passwordless(object):
         return self._request_helper
 
     def create_session(self, session_options):
-        """Create an Passwordless Session.
+        """Create a Passwordless Session.
 
         Args:
             session_options (dict) - An session options object

--- a/workos/passwordless.py
+++ b/workos/passwordless.py
@@ -48,7 +48,7 @@ class Passwordless(object):
       				Session to send an email for.
 
         Returns:
-            dict: {"success": true} if successful
+            boolean: Returns True
         """
         self.request_helper.request(
             "passwordless/sessions/{session_id}/send".format(session_id=session_id),

--- a/workos/passwordless.py
+++ b/workos/passwordless.py
@@ -45,7 +45,7 @@ class Passwordless(object):
 
         Args:
             session_id (str): The unique identifier of the Passwordless
-      				Session to send an email for.
+                Session to send an email for.
 
         Returns:
             boolean: Returns True

--- a/workos/utils/validation.py
+++ b/workos/utils/validation.py
@@ -5,12 +5,14 @@ from workos.exceptions import ConfigurationException
 
 AUDIT_TRAIL_MODULE = "AuditTrail"
 DIRECTORY_SYNC_MODULE = "DirectorySync"
+PASSWORDLESS_MODULE = "Passwordless"
 PORTAL_MODULE = "Portal"
 SSO_MODULE = "SSO"
 
 REQUIRED_SETTINGS_FOR_MODULE = {
     AUDIT_TRAIL_MODULE: ["api_key",],
     DIRECTORY_SYNC_MODULE: ["api_key",],
+    PASSWORDLESS_MODULE: ["api_key",],
     PORTAL_MODULE: ["api_key",],
     SSO_MODULE: ["api_key", "project_id",],
 }


### PR DESCRIPTION
Add Passwordless support for MagicLink. Adds two methods:
- `create_session` - generate a passwordless session for a user from their email
- `send_session` - send an email to a user with a Magic Link confirmation URL