### PR TITLE
Expose `connection_id` on Profile Objects

### DIFF
--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -26,6 +26,7 @@ class TestSSO(object):
             "email": "demo@workos-okta.com",
             "first_name": "WorkOS",
             "last_name": "Demo",
+            "connection_id": "conn_01EMH8WAK20T42N2NBMNBCYHAG"
             "connection_type": "OktaSAML",
             "idp_id": "00u1klkowm8EGah2H357",
             "raw_attributes": {
@@ -135,6 +136,7 @@ class TestSSO(object):
                 "id": mock_profile["id"],
                 "email": mock_profile["email"],
                 "first_name": mock_profile["first_name"],
+                "connection_id": mock_profile["connection_id"],
                 "connection_type": mock_profile["connection_type"],
                 "last_name": mock_profile["last_name"],
                 "idp_id": mock_profile["idp_id"],

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -26,7 +26,7 @@ class TestSSO(object):
             "email": "demo@workos-okta.com",
             "first_name": "WorkOS",
             "last_name": "Demo",
-            "connection_id": "conn_01EMH8WAK20T42N2NBMNBCYHAG"
+            "connection_id": "conn_01EMH8WAK20T42N2NBMNBCYHAG",
             "connection_type": "OktaSAML",
             "idp_id": "00u1klkowm8EGah2H357",
             "raw_attributes": {

--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 __author__ = "WorkOS"
 

--- a/workos/resources/sso.py
+++ b/workos/resources/sso.py
@@ -13,6 +13,7 @@ class WorkOSProfile(WorkOSBaseResource):
         "email",
         "first_name",
         "last_name",
+        "connection_id",
         "connection_type",
         "idp_id",
         "raw_attributes",


### PR DESCRIPTION
This PR introduces the following changes:

* Passes the `connection_id` Profile object attribute through to the SDK. We currently expose `connection_id` via the `/sso/token` API endpoint.
* Updates the SDK version to `0.8.0`.