### PR TITLE
Updating to fix typo in Readme Pyhon -> Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # workos-python
 
-Pyhon SDK to conveniently access the [WorkOS API](https://workos.com).
+Python SDK to conveniently access the [WorkOS API](https://workos.com).
 
 ## Installation
 


### PR DESCRIPTION
Updating typo of `Pyhon` in README caught by a customer