### PR TITLE
Add `GET /connections/:id`

### DIFF
--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -208,6 +208,16 @@ class TestSSO(object):
         connection = self.sso.create_connection("draft_conn_id")
         assert connection == response_dict
 
+    def test_get_connection(self, mock_connection, mock_request_method):
+        mock_response = Response()
+        mock_response.status_code = 200
+        mock_response.response_dict = mock_connection
+        mock_request_method("get", mock_response, 200)
+        response = self.sso.get_connection(connection="connection_id")
+        assert response.status_code == 200
+        assert response.response_dict == mock_connection
+
+
     def test_list_connections(self, mock_connections, mock_request_method):
         mock_response = Response()
         mock_response.status_code = 200

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -217,7 +217,6 @@ class TestSSO(object):
         assert response.status_code == 200
         assert response.response_dict == mock_connection
 
-
     def test_list_connections(self, mock_connections, mock_request_method):
         mock_response = Response()
         mock_response.status_code = 200

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -165,6 +165,21 @@ class SSO(object):
             token=workos.api_key,
         )
 
+    def get_connection(self, connection):
+        """Gets details for a single Connection
+
+        Args:
+            connection (str): Connection unique identifier
+
+        Returns:
+            dict: Connection response from WorkOS.
+        """
+        return self.request_helper.request(
+            "connections/{connection}".format(connection=connection),
+            method=REQUEST_METHOD_GET,
+            token=workos.api_key,
+        )
+
     def list_connections(
         self,
         connection_type=None,
@@ -186,7 +201,7 @@ class SSO(object):
             dict: Connections response from WorkOS.
         """
         params = {
-            "connetion_type": connection_type,
+            "connection_type": connection_type,
             "domain": domain,
             "limit": limit,
             "before": before,


### PR DESCRIPTION
This PR introduces the following changes:

- Adds functionality to retrieve a single Connection using the WorkOS SSO REST API