### PR TITLE
Add `organization_id` Parameter to `list_connections`

### DIFF
--- a/workos/sso.py
+++ b/workos/sso.py
@@ -185,6 +185,7 @@ class SSO(object):
         self,
         connection_type=None,
         domain=None,
+        organization_id=None,
         limit=RESPONSE_LIMIT,
         before=None,
         after=None,
@@ -204,6 +205,7 @@ class SSO(object):
         params = {
             "connection_type": connection_type,
             "domain": domain,
+            "organization_id": organization_id,
             "limit": limit,
             "before": before,
             "after": after,


### PR DESCRIPTION
This PR introduces the following changes:

- Adds support for an `organization_id` parameter to the `list_connections` function. Allows for retrieving a list of all Connections associated with the given `organization_id`.