### PR TITLE
Remove support for deprecated `project_id` parameter

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,17 +25,7 @@ def set_client_id(monkeypatch):
 
 
 @pytest.fixture
-def set_project_id(monkeypatch):
-    monkeypatch.setattr(workos, "project_id", "project_b27needthisforssotemxo")
-
-
-@pytest.fixture
 def set_api_key_and_client_id(set_api_key, set_client_id):
-    pass
-
-
-@pytest.fixture
-def set_api_key_and_project_id(set_api_key, set_project_id):
     pass
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,7 @@ class TestClient(object):
         client._portal = None
         client._sso = None
 
-    def test_initialize_sso(self, set_api_key_and_project_id):
+    def test_initialize_sso(self, set_api_key_and_client_id):
         assert bool(client.sso)
 
     def test_initialize_audit_log(self, set_api_key):
@@ -28,14 +28,14 @@ class TestClient(object):
     def test_initialize_portal(self, set_api_key):
         assert bool(client.portal)
 
-    def test_initialize_sso_missing_api_key(self, set_project_id):
+    def test_initialize_sso_missing_api_key(self, set_client_id):
         with pytest.raises(ConfigurationException) as ex:
             client.sso
 
         message = str(ex)
 
         assert "api_key" in message
-        assert "project_id" not in message
+        assert "client_id" not in message
 
     def test_initialize_sso_missing_client_id(self, set_api_key):
         with pytest.raises(ConfigurationException) as ex:
@@ -46,7 +46,7 @@ class TestClient(object):
         assert "client_id" in message
         assert "api_key" not in message
 
-    def test_initialize_sso_missing_api_key_and_project_id(self):
+    def test_initialize_sso_missing_api_key_and_client_id(self):
         with pytest.raises(ConfigurationException) as ex:
             client.sso
 

--- a/tests/test_directory_sync.py
+++ b/tests/test_directory_sync.py
@@ -104,8 +104,7 @@ class TestDirectorySync(object):
                     "state": "linked",
                     "type": "gsuite directory",
                     "name": "Ri Jeong Hyeok",
-                    "bearer_token": None,
-                    "project_id": "project_id",
+                    "environment_id": "environment_id",
                     "domain": "crashlandingonyou.com",
                 }
             ],

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -9,7 +9,7 @@ from workos.passwordless import Passwordless
 
 class TestPasswordless(object):
     @pytest.fixture(autouse=True)
-    def setup(self, set_api_key_and_project_id):
+    def setup(self, set_api_key_and_client_id):
         self.passwordless = Passwordless()
 
     @pytest.fixture

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -22,7 +22,7 @@ class TestSSO(object):
         self.sso = SSO()
 
     @pytest.fixture
-    def setup_with_project_id(self, set_api_key_and_project_id):
+    def setup_with_client_id(self, set_api_key_and_client_id):
         self.provider = ConnectionType.GoogleOAuth
         self.customer_domain = "workos.com"
         self.redirect_uri = "https://localhost/auth/callback"
@@ -193,28 +193,6 @@ class TestSSO(object):
             "response_type": RESPONSE_TYPE_CODE,
             "state": self.state,
         }
-
-    def test_authorization_url_supports_project_id_with_deprecation_warning(
-        self, setup_with_project_id
-    ):
-        with pytest.deprecated_call():
-            authorization_url = self.sso.get_authorization_url(
-                domain=self.customer_domain,
-                provider=self.provider,
-                redirect_uri=self.redirect_uri,
-                state=self.state,
-            )
-
-            parsed_url = urlparse(authorization_url)
-
-            assert dict(parse_qsl(parsed_url.query)) == {
-                "domain": self.customer_domain,
-                "provider": str(self.provider.value),
-                "client_id": workos.project_id,
-                "redirect_uri": self.redirect_uri,
-                "response_type": RESPONSE_TYPE_CODE,
-                "state": self.state,
-            }
 
     def test_get_profile_returns_expected_workosprofile_object(
         self, setup_with_client_id, mock_profile, mock_request_method

--- a/workos/__init__.py
+++ b/workos/__init__.py
@@ -4,6 +4,5 @@ from workos.__about__ import __version__
 from workos.client import client
 
 api_key = os.getenv("WORKOS_API_KEY")
-project_id = os.getenv("WORKOS_PROJECT_ID")
 client_id = os.getenv("WORKOS_CLIENT_ID")
 base_api_url = "https://api.workos.com/"

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -80,13 +80,6 @@ class SSO(object):
         if state is not None:
             params["state"] = state
 
-        if workos.project_id is not None:
-            params["client_id"] = workos.project_id
-            warn(
-                "'project_id' is deprecated. Use 'client_id' instead.",
-                DeprecationWarning,
-            )
-
         prepared_request = Request(
             "GET",
             self.request_helper.generate_api_url(AUTHORIZATION_PATH),
@@ -113,13 +106,6 @@ class SSO(object):
             "code": code,
             "grant_type": OAUTH_GRANT_TYPE,
         }
-
-        if workos.project_id is not None:
-            params["client_id"] = workos.project_id
-            warn(
-                "'project_id' is deprecated. Use 'client_id' instead.",
-                DeprecationWarning,
-            )
 
         response = self.request_helper.request(
             TOKEN_PATH, method=REQUEST_METHOD_POST, params=params

--- a/workos/utils/validation.py
+++ b/workos/utils/validation.py
@@ -24,19 +24,9 @@ def validate_settings(module_name):
         def wrapper(*args, **kwargs):
             missing_settings = []
 
-            # Adding this to accept both client_id and project_id
-            # can remove once project_id is deprecated
-            if module_name == SSO_MODULE:
-                if not getattr(workos, "api_key", None):
-                    missing_settings.append("api_key")
-                if not getattr(workos, "client_id", None) and not getattr(
-                    workos, "project_id", None
-                ):
-                    missing_settings.append("client_id")
-            else:
-                for setting in REQUIRED_SETTINGS_FOR_MODULE[module_name]:
-                    if not getattr(workos, setting, None):
-                        missing_settings.append(setting)
+            for setting in REQUIRED_SETTINGS_FOR_MODULE[module_name]:
+                if not getattr(workos, setting, None):
+                    missing_settings.append(setting)
 
             if missing_settings:
                 raise ConfigurationException(


### PR DESCRIPTION
This PR removes support for the deprecated `project_id` parameter.

This is a breaking change that will be part of `v1.0.0`.

Resolves SDK-164.