### PR TITLE
Rename `get_profile` to `get_profile_and_token`

### DIFF
--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -185,7 +185,7 @@ class TestSSO(object):
             "state": self.state,
         }
 
-    def test_get_profile_returns_expected_workosprofile_object(
+    def test_get_profile_and_token_returns_expected_workosprofile_object(
         self, setup_with_client_id, mock_profile, mock_request_method
     ):
         response_dict = {
@@ -209,9 +209,10 @@ class TestSSO(object):
 
         mock_request_method("post", response_dict, 200)
 
-        profile = self.sso.get_profile(123)
+        profile_and_token = self.sso.get_profile_and_token(123)
 
-        assert profile.to_dict() == mock_profile
+        assert profile_and_token.access_token == "01DY34ACQTM3B1CSX1YSZ8Z00D"
+        assert profile_and_token.profile.to_dict() == mock_profile
 
     def test_create_connection(
         self, setup_with_client_id, mock_request_method, mock_connection

--- a/workos/resources/sso.py
+++ b/workos/resources/sso.py
@@ -18,3 +18,30 @@ class WorkOSProfile(WorkOSBaseResource):
         "idp_id",
         "raw_attributes",
     ]
+
+class WorkOSProfileAndToken(WorkOSBaseResource):
+    """Representation of a User Profile and Access Token as returned by WorkOS through the SSO feature.
+
+    Attributes:
+        OBJECT_FIELDS (list): List of fields a WorkOSProfileAndToken is comprised of.
+    """
+
+    OBJECT_FIELDS = [
+        "access_token",
+    ]
+
+    @classmethod
+    def construct_from_response(cls, response):
+        profile_and_token = super(WorkOSProfileAndToken, cls).construct_from_response(response)
+
+        profile_and_token.profile = WorkOSProfile.construct_from_response(response["profile"])
+
+        return profile_and_token
+
+    def to_dict(self):
+        profile_and_token_dict = super(WorkOSProfileAndToken, self).to_dict()
+
+        profile_dict = self.profile.to_dict()
+        profile_and_token_dict["profile"] = profile_dict
+
+        return profile_and_token_dict

--- a/workos/resources/sso.py
+++ b/workos/resources/sso.py
@@ -19,6 +19,7 @@ class WorkOSProfile(WorkOSBaseResource):
         "raw_attributes",
     ]
 
+
 class WorkOSProfileAndToken(WorkOSBaseResource):
     """Representation of a User Profile and Access Token as returned by WorkOS through the SSO feature.
 
@@ -32,9 +33,13 @@ class WorkOSProfileAndToken(WorkOSBaseResource):
 
     @classmethod
     def construct_from_response(cls, response):
-        profile_and_token = super(WorkOSProfileAndToken, cls).construct_from_response(response)
+        profile_and_token = super(WorkOSProfileAndToken, cls).construct_from_response(
+            response
+        )
 
-        profile_and_token.profile = WorkOSProfile.construct_from_response(response["profile"])
+        profile_and_token.profile = WorkOSProfile.construct_from_response(
+            response["profile"]
+        )
 
         return profile_and_token
 

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -5,7 +5,7 @@ from warnings import warn
 
 import workos
 from workos.exceptions import ConfigurationException
-from workos.resources.sso import WorkOSProfile
+from workos.resources.sso import WorkOSProfileAndToken
 from workos.utils.connection_types import ConnectionType
 from workos.utils.request import (
     RequestHelper,

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -98,7 +98,7 @@ class SSO(object):
             code (str): Code returned by WorkOS on completion of OAuth 2.0 workflow
 
         Returns:
-            WorkOSProfile: WorkOSProfile object representing the User
+            WorkOSProfileAndToken: WorkOSProfileAndToken object representing the User
         """
         params = {
             "client_id": workos.client_id,
@@ -111,7 +111,7 @@ class SSO(object):
             TOKEN_PATH, method=REQUEST_METHOD_POST, params=params
         )
 
-        return WorkOSProfile.construct_from_response(response["profile"])
+        return WorkOSProfileAndToken.construct_from_response(response)
 
     def promote_draft_connection(self, token):
         """Promote a Draft Connection

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -88,7 +88,7 @@ class SSO(object):
 
         return prepared_request.url
 
-    def get_profile(self, code):
+    def get_profile_and_token(self, code):
         """Get the profile of an authenticated User
 
         Once authenticated, using the code returned having followed the authorization URL,


### PR DESCRIPTION
This PR renames the `get_profile` method to `get_profile_and_token`.

This is a breaking change that will be part of `v1.0.0`.

Resolves SDK-157.