### PR TITLE
Remove `create_connection` and `promote_draft_connection` methods

### DIFF
--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -214,31 +214,6 @@ class TestSSO(object):
         assert profile_and_token.access_token == "01DY34ACQTM3B1CSX1YSZ8Z00D"
         assert profile_and_token.profile.to_dict() == mock_profile
 
-    def test_create_connection(
-        self, setup_with_client_id, mock_request_method, mock_connection
-    ):
-        response_dict = {
-            "object": "connection",
-            "id": mock_connection["id"],
-            "name": mock_connection["name"],
-            "status": mock_connection["status"],
-            "connection_type": mock_connection["connection_type"],
-            "oauth_uid": mock_connection["oauth_uid"],
-            "oauth_secret": mock_connection["oauth_secret"],
-            "oauth_redirect_uri": mock_connection["oauth_redirect_uri"],
-            "saml_entity_id": mock_connection["saml_entity_id"],
-            "saml_idp_url": mock_connection["saml_idp_url"],
-            "saml_relying_party_trust_cert": mock_connection[
-                "saml_relying_party_trust_cert"
-            ],
-            "saml_x509_certs": mock_connection["saml_x509_certs"],
-            "domains": mock_connection["domains"],
-        }
-        mock_request_method("post", mock_connection, 201)
-
-        connection = self.sso.create_connection("draft_conn_id")
-        assert connection == response_dict
-
     def test_get_connection(
         self, setup_with_client_id, mock_connection, mock_request_method
     ):

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -17,8 +17,6 @@ from workos.utils.request import (
 from workos.utils.validation import SSO_MODULE, validate_settings
 
 AUTHORIZATION_PATH = "sso/authorize"
-CREATE_CONNECTION_PATH = "connections"
-PROMOTE_DRAFT_CONNECTION_PATH = "draft_connections/%s/activate"
 TOKEN_PATH = "sso/token"
 
 OAUTH_GRANT_TYPE = "authorization_code"
@@ -112,48 +110,6 @@ class SSO(object):
         )
 
         return WorkOSProfileAndToken.construct_from_response(response)
-
-    def promote_draft_connection(self, token):
-        """Promote a Draft Connection
-
-        Promotes a Draft Connection created through the WorkOS.js embed. A Draft Connection that has
-        been promoted will enable Enterprise users of the domain to begin signing in via SSO.
-
-        Args:
-            token (str): The token supplied via the response when a draft connection is created via
-            the WorkOS.js embed
-
-        Returns:
-            bool: True if a Draft Connection has been successfully promoted
-        """
-        warn(
-            "'promote_draft_connection' is deprecated. Use 'create_connection' instead.",
-            DeprecationWarning,
-        )
-        self.request_helper.request(
-            PROMOTE_DRAFT_CONNECTION_PATH % token,
-            method=REQUEST_METHOD_POST,
-            token=workos.api_key,
-        )
-
-        return True
-
-    def create_connection(self, source):
-        """Activates a Draft Connection created through the WorkOS.js widget.
-
-        Args:
-            source (str): Draft Connection identifier.
-
-        Returns:
-            dict: Created Connection response from WorkOS.
-        """
-        params = {"source": source}
-        return self.request_helper.request(
-            CREATE_CONNECTION_PATH,
-            method=REQUEST_METHOD_POST,
-            params=params,
-            token=workos.api_key,
-        )
 
     def get_connection(self, connection):
         """Gets details for a single Connection


### PR DESCRIPTION
This PR removes the deprecated `create_connection` and `promote_draft_connection` methods from the SDK.

This is a breaking change that will be part of `v1.0.0`.

Resolves SDK-178.