### PR TITLE
v1.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 WorkOS
+Copyright (c) 2021 WorkOS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "0.8.7"
+__version__ = "1.0.0"
 
 __author__ = "WorkOS"
 


### PR DESCRIPTION
## Breaking Changes

- `sso.get_profile` has been renamed to `sso.get_profile_and_token` (#67)
  - The return type has also been changed from `Profile` to `ProfileAndToken`
- Organization operations have been moved from the `portal` namespace to `organizations` (#68)
  - `portal.list_organizations` &rarr; `organizations.list_organizations`
  - `portal.create_organization` &rarr; `organizations.create_organization`
-  `sso.create_connection` and `sso.promote_draft_connection` have been removed (#69)

## Removed Deprecations

- The deprecated `project_id` parameter has been fully removed. The `client_id` parameter should be used instead (#66)

Resolves SDK-185.