### PR TITLE
Expose `organizations` on `Client`

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,7 @@ class TestClient(object):
     def setup(self):
         client._audit_trail = None
         client._directory_sync = None
+        client._organizations = None
         client._passwordless = None
         client._portal = None
         client._sso = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -22,6 +22,9 @@ class TestClient(object):
     def test_initialize_directory_sync(self, set_api_key):
         assert bool(client.directory_sync)
 
+    def test_initialize_organizations(self, set_api_key):
+        assert bool(client.organizations)
+
     def test_initialize_passwordless(self, set_api_key):
         assert bool(client.passwordless)
 
@@ -65,6 +68,14 @@ class TestClient(object):
     def test_initialize_directory_sync_missing_api_key(self):
         with pytest.raises(ConfigurationException) as ex:
             client.directory_sync
+
+        message = str(ex)
+
+        assert "api_key" in message
+
+    def test_initialize_organizations_missing_api_key(self):
+        with pytest.raises(ConfigurationException) as ex:
+            client.organizations
 
         message = str(ex)
 

--- a/workos/client.py
+++ b/workos/client.py
@@ -1,5 +1,6 @@
 from workos.audit_trail import AuditTrail
 from workos.directory_sync import DirectorySync
+from workos.organizations import Organizations
 from workos.passwordless import Passwordless
 from workos.portal import Portal
 from workos.sso import SSO
@@ -25,6 +26,12 @@ class Client(object):
         if not getattr(self, "_directory_sync", None):
             self._directory_sync = DirectorySync()
         return self._directory_sync
+
+    @property
+    def organizations(self):
+        if not getattr(self, "_organizations", None):
+            self._organizations = Organizations()
+        return self._organizations
 
     @property
     def passwordless(self):

--- a/workos/utils/validation.py
+++ b/workos/utils/validation.py
@@ -13,7 +13,7 @@ SSO_MODULE = "SSO"
 REQUIRED_SETTINGS_FOR_MODULE = {
     AUDIT_TRAIL_MODULE: ["api_key",],
     DIRECTORY_SYNC_MODULE: ["api_key",],
-    ORGANIZATIONS_MODULE: ["api_key"],
+    ORGANIZATIONS_MODULE: ["api_key",],
     PASSWORDLESS_MODULE: ["api_key",],
     PORTAL_MODULE: ["api_key",],
     SSO_MODULE: ["api_key", "client_id",],


### PR DESCRIPTION
This PR fixes an issue where the `organizations` property was missing from the `Client`.

Resolves SDK-195.