### PR TITLE
Add support for error and error_description

### DIFF
--- a/tests/utils/test_requests.py
+++ b/tests/utils/test_requests.py
@@ -42,7 +42,7 @@ class TestRequestHelper(object):
         for status_code, exception in STATUS_CODE_TO_EXCEPTION_MAPPING.items():
             mock_request_method(
                 "get",
-                {"message": response_message,},
+                {"message": response_message},
                 status_code,
                 headers={"X-Request-ID": request_id},
             )
@@ -55,6 +55,32 @@ class TestRequestHelper(object):
             except Exception as ex:
                 # This'll fail for sure here but... just using the nice error that'd come up
                 assert ex.__class__ == exception
+
+    def test_bad_request_exceptions_include_expected_request_data(
+        self, mock_request_method
+    ):
+        request_helper = RequestHelper()
+
+        request_id = "request-123"
+        error = "example_error"
+        error_description = "Example error description"
+
+        mock_request_method(
+            "get",
+            {"error": error, "error_description": error_description},
+            400,
+            headers={"X-Request-ID": request_id},
+        )
+
+        try:
+            request_helper.request("bad_place")
+        except ServerException as ex:
+            assert ex.request_id == request_id
+            assert ex.error == error
+            assert ex.error_description == error_description
+        except Exception as ex:
+            # This'll fail for sure here but... just using the nice error that'd come up
+            assert ex.__class__ == BadRequestException
 
     def test_request_bad_body_raises_expected_exception_with_request_data(
         self, mock_request_method

--- a/workos/exceptions.py
+++ b/workos/exceptions.py
@@ -4,7 +4,7 @@ class ConfigurationException(Exception):
 
 # Request related exceptions
 class BaseRequestException(Exception):
-    def __init__(self, response, message=None, error=None):
+    def __init__(self, response, message=None, error=None, error_description=None):
         super(BaseRequestException, self).__init__(message)
 
         self.error = error
@@ -34,6 +34,9 @@ class BaseRequestException(Exception):
 
         if self.error is not None:
             exception += ", error=%s" % self.error
+
+        if self.error_description is not None:
+            exception += ", error_description=%s" % self.error_description
 
         return exception + ")"
 

--- a/workos/utils/request.py
+++ b/workos/utils/request.py
@@ -79,7 +79,10 @@ class RequestHelper(object):
             elif status_code == 403:
                 raise AuthorizationException(response)
             error = response_json.get("error")
-            raise BadRequestException(response, error=error)
+            error_description = response_json.get("error_description")
+            raise BadRequestException(
+                response, error=error, error_description=error_description
+            )
         elif status_code >= 500 and status_code < 600:
             raise ServerException(response)
 


### PR DESCRIPTION
Add support for `error` and `error_description` for 400 errors. Targeting better error handling in SDKs for the POST /sso/token endpoint