### PR TITLE
Fix ServerException for successful DELETE operations

### DIFF
--- a/tests/test_audit_trail.py
+++ b/tests/test_audit_trail.py
@@ -1,10 +1,8 @@
 from datetime import datetime
 import json
-from requests import Response
 
 import pytest
 
-import workos
 from workos.audit_trail import AuditTrail
 
 
@@ -26,9 +24,7 @@ class TestAuditTrail(object):
             "occurred_at": datetime.now().isoformat(),
             "metadata": {"a": "b"},
         }
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_request_method("post", mock_response, 200)
+        mock_request_method("post", "{}", 200)
 
         result = self.audit_trail.create_event(event)
         assert result == True
@@ -75,7 +71,7 @@ class TestAuditTrail(object):
             "data": [event,],
             "listMetadata": {"before": None, "after": None,},
         }
-        mock_request_method("get", response, 200)
+        mock_request_method("get", json.dumps(response), 200)
 
         events, before, after = self.audit_trail.get_events()
         assert events[0].to_dict() == event
@@ -107,7 +103,8 @@ class TestAuditTrail(object):
             "data": [event,],
             "listMetadata": {"before": None, "after": None,},
         }
-        request_args, request_kwargs = capture_and_mock_request("get", response, 200)
+        request_args, request_kwargs = capture_and_mock_request(
+            "get", json.dumps(response), 200)
 
         self.audit_trail.get_events(
             occurred_at=datetime.now(),
@@ -151,7 +148,8 @@ class TestAuditTrail(object):
             "data": [event,],
             "listMetadata": {"before": None, "after": None,},
         }
-        request_args, request_kwargs = capture_and_mock_request("get", response, 200)
+        request_args, request_kwargs = capture_and_mock_request(
+            "get", json.dumps(response), 200)
 
         self.audit_trail.get_events(
             occurred_at_gte=datetime.now(), occurred_at_gt=datetime.now(),
@@ -188,7 +186,8 @@ class TestAuditTrail(object):
             "data": [event,],
             "listMetadata": {"before": None, "after": None,},
         }
-        request_args, request_kwargs = capture_and_mock_request("get", response, 200)
+        request_args, request_kwargs = capture_and_mock_request(
+            "get", json.dumps(response), 200)
 
         self.audit_trail.get_events(
             occurred_at_lte=datetime.now, occurred_at_lt=datetime.now()

--- a/tests/test_directory_sync.py
+++ b/tests/test_directory_sync.py
@@ -1,11 +1,8 @@
 import json
-from requests import Response
 
 import pytest
 
-import workos
 from workos.directory_sync import DirectorySync
-from workos.utils.request import RESPONSE_TYPE_CODE
 
 
 class TestDirectorySync(object):
@@ -112,71 +109,41 @@ class TestDirectorySync(object):
         }
 
     def test_list_users_with_directory(self, mock_users, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_users
-        mock_request_method("get", mock_response, 200)
+        mock_request_method("get", json.dumps(mock_users), 200)
         response = self.directory_sync.list_users(directory="directory_id")
-        assert response.status_code == 200
-        assert response.response_dict == mock_users
+        assert response == mock_users
 
     def test_list_users_with_group(self, mock_users, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_users
-        mock_request_method("get", mock_response, 200)
+        mock_request_method("get", json.dumps(mock_users), 200)
         response = self.directory_sync.list_users(group="directory_grp_id")
-        assert response.status_code == 200
-        assert response.response_dict == mock_users
+        assert response == mock_users
 
     def test_list_groups_with_directory(self, mock_groups, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_groups
-        mock_request_method("get", mock_response, 200)
+        mock_request_method("get", json.dumps(mock_groups), 200)
         response = self.directory_sync.list_groups(directory="directory_id")
-        assert response.status_code == 200
-        assert response.response_dict == mock_groups
+        assert response == mock_groups
 
     def test_list_groups_with_user(self, mock_groups, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_groups
-        mock_request_method("get", mock_response, 200)
+        mock_request_method("get", json.dumps(mock_groups), 200)
         response = self.directory_sync.list_groups(user="directory_usr_id")
-        assert response.status_code == 200
-        assert response.response_dict == mock_groups
+        assert response == mock_groups
 
     def test_get_user(self, mock_user, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_user
-        mock_request_method("get", mock_response, 200)
+        mock_request_method("get", json.dumps(mock_user), 200)
         response = self.directory_sync.get_user(user="directory_usr_id")
-        assert response.status_code == 200
-        assert response.response_dict == mock_user
+        assert response == mock_user
 
     def test_get_group(self, mock_group, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_group
-        mock_request_method("get", mock_response, 200)
+        mock_request_method("get", json.dumps(mock_group), 200)
         response = self.directory_sync.get_group(group="directory_grp_id")
-        assert response.status_code == 200
-        assert response.response_dict == mock_group
+        assert response == mock_group
 
     def test_list_directories(self, mock_directories, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_directories
-        mock_request_method("get", mock_response, 200)
+        mock_request_method("get", json.dumps(mock_directories), 200)
         response = self.directory_sync.list_directories()
-        assert response.status_code == 200
-        assert response.response_dict == mock_directories
+        assert response == mock_directories
 
     def test_delete_directory(self, mock_directories, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 202
-        mock_request_method("delete", mock_response, 202)
+        mock_request_method("delete", "{}", 202)
         response = self.directory_sync.delete_directory(directory="directory_id")
-        assert response.status_code == 202
+        assert response == {}

--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -114,6 +114,12 @@ class TestOrganizations(object):
         ]
 
     def test_delete_organization(self, setup, mock_request_method):
-        mock_request_method("delete", "{}", 204)
+        # The organization delete endpoint returns 'Accepted' and a Content-Type of text/plain
+        mock_request_method(
+            "delete",
+            "Accepted",
+            204,
+            headers={"content-type": "text/plain; charset=utf-8"},
+        )
         response = self.organizations.delete_organization(organization="connection_id")
-        assert response == {}
+        assert response is None

--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -1,9 +1,7 @@
 import json
-from requests import Response
 
 import pytest
 
-import workos
 from workos.organizations import Organizations
 
 
@@ -76,48 +74,34 @@ class TestOrganizations(object):
         }
 
     def test_list_organizations(self, mock_organizations, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_organizations
-        mock_request_method("get", mock_response, 200)
+        mock_request_method("get", json.dumps(mock_organizations), 200)
         response = self.organizations.list_organizations()
-        assert response.status_code == 200
-        assert len(response.response_dict["data"]) == 2
+        assert len(response["data"]) == 2
 
     def test_get_organization(self, mock_organization, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_organization
-        mock_request_method("get", mock_response, 200)
+        mock_request_method("get", json.dumps(mock_organization), 200)
         response = self.organizations.get_organization(organization="organization_id")
-        assert response.status_code == 200
-        assert response.response_dict == mock_organization
+        assert response == mock_organization
 
     def test_create_organization(self, mock_organization, mock_request_method):
         organization = {"domains": ["example.com"], "name": "Test Organization"}
-        mock_response = Response()
-        mock_response.status_code = 201
-        mock_response.response_dict = mock_organization
-        mock_request_method("post", mock_response, 201)
+        mock_request_method("post", json.dumps(mock_organization), 201)
 
         result = self.organizations.create_organization(organization)
-        subject = result.response_dict
+        subject = result
 
         assert subject["id"] == "org_01EHT88Z8J8795GZNQ4ZP1J81T"
         assert subject["name"] == "Test Organization"
 
     def test_update_organization(self, mock_organization_updated, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 201
-        mock_response.response_dict = mock_organization_updated
-        mock_request_method("put", mock_response, 201)
+        mock_request_method("put", json.dumps(mock_organization_updated), 201)
 
         result = self.organizations.update_organization(
             organization="org_01EHT88Z8J8795GZNQ4ZP1J81T",
             name="Example Organization",
             domains=["example.io"],
         )
-        subject = result.response_dict
+        subject = result
 
         assert subject["id"] == "org_01EHT88Z8J8795GZNQ4ZP1J81T"
         assert subject["name"] == "Example Organization"
@@ -130,8 +114,6 @@ class TestOrganizations(object):
         ]
 
     def test_delete_organization(self, setup, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 204
-        mock_request_method("delete", mock_response, 204)
+        mock_request_method("delete", "{}", 204)
         response = self.organizations.delete_organization(organization="connection_id")
-        assert response.status_code == 204
+        assert response == {}

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -1,9 +1,7 @@
 import json
-from requests import Response
 
 import pytest
 
-import workos
 from workos.passwordless import Passwordless
 
 
@@ -25,10 +23,7 @@ class TestPasswordless(object):
     def test_create_session_succeeds(
         self, mock_passwordless_session, mock_request_method
     ):
-        mock_response = Response()
-        mock_response.status_code = 201
-        mock_response.response_dict = mock_passwordless_session
-        mock_request_method("post", mock_response, 201)
+        mock_request_method("post", json.dumps(mock_passwordless_session), 201)
 
         session_options = {
             "email": "demo@workos-okta.com",
@@ -36,16 +31,15 @@ class TestPasswordless(object):
         }
         response = self.passwordless.create_session(session_options)
 
-        assert response.status_code == 201
-        assert response.response_dict == mock_passwordless_session
+        assert response == mock_passwordless_session
 
     def test_get_send_session_succeeds(self, mock_request_method):
         response = {
             "success": True,
         }
-        mock_request_method("post", response, 200)
+        mock_request_method("post", json.dumps(response), 200)
 
         response = self.passwordless.send_session(
             "passwordless_session_01EHDAK2BFGWCSZXP9HGZ3VK8C"
         )
-        assert response == True
+        assert response is True

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -1,9 +1,7 @@
 import json
-from requests import Response
 
 import pytest
 
-import workos
 from workos.portal import Portal
 
 
@@ -17,23 +15,17 @@ class TestPortal(object):
         return {"link": "https://id.workos.com/portal/launch?secret=secret"}
 
     def test_generate_link_sso(self, mock_portal_link, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 201
-        mock_response.response_dict = mock_portal_link
-        mock_request_method("post", mock_response, 201)
+        mock_request_method("post", json.dumps(mock_portal_link), 201)
 
         result = self.portal.generate_link("sso", "org_01EHQMYV6MBK39QC5PZXHY59C3")
-        subject = result.response_dict
+        subject = result
 
         assert subject["link"] == "https://id.workos.com/portal/launch?secret=secret"
 
     def test_generate_link_dsync(self, mock_portal_link, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 201
-        mock_response.response_dict = mock_portal_link
-        mock_request_method("post", mock_response, 201)
+        mock_request_method("post", json.dumps(mock_portal_link), 201)
 
         result = self.portal.generate_link("dsync", "org_01EHQMYV6MBK39QC5PZXHY59C3")
-        subject = result.response_dict
+        subject = result
 
         assert subject["link"] == "https://id.workos.com/portal/launch?secret=secret"

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -1,5 +1,4 @@
 import json
-from requests import Response
 from six.moves.urllib.parse import parse_qsl, urlparse
 
 import pytest
@@ -207,7 +206,7 @@ class TestSSO(object):
             "access_token": "01DY34ACQTM3B1CSX1YSZ8Z00D",
         }
 
-        mock_request_method("post", response_dict, 200)
+        mock_request_method("post", json.dumps(response_dict), 200)
 
         profile_and_token = self.sso.get_profile_and_token(123)
 
@@ -217,28 +216,18 @@ class TestSSO(object):
     def test_get_connection(
         self, setup_with_client_id, mock_connection, mock_request_method
     ):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_connection
-        mock_request_method("get", mock_response, 200)
+        mock_request_method("get", json.dumps(mock_connection), 200)
         response = self.sso.get_connection(connection="connection_id")
-        assert response.status_code == 200
-        assert response.response_dict == mock_connection
+        assert response == mock_connection
 
     def test_list_connections(
         self, setup_with_client_id, mock_connections, mock_request_method
     ):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_connections
-        mock_request_method("get", mock_response, 200)
+        mock_request_method("get", json.dumps(mock_connections), 200)
         response = self.sso.list_connections()
-        assert response.status_code == 200
-        assert response.response_dict == mock_connections
+        assert response == mock_connections
 
     def test_delete_connection(self, setup_with_client_id, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 204
-        mock_request_method("delete", mock_response, 204)
+        mock_request_method("delete", "{}", 204)
         response = self.sso.delete_connection(connection="connection_id")
-        assert response.status_code == 204
+        assert response == {}

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -228,6 +228,7 @@ class TestSSO(object):
         assert response == mock_connections
 
     def test_delete_connection(self, setup_with_client_id, mock_request_method):
-        mock_request_method("delete", "{}", 204)
+        # The connection delete endpoint returns nothing and doesn't define a content-type
+        mock_request_method("delete", "", 204, headers={"content-type": ""})
         response = self.sso.delete_connection(connection="connection_id")
-        assert response == {}
+        assert response is None

--- a/tests/utils/test_requests.py
+++ b/tests/utils/test_requests.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 
 from workos.exceptions import (
@@ -26,7 +27,7 @@ class TestRequestHelper(object):
         request_helper = RequestHelper()
 
         for status_code, exception in STATUS_CODE_TO_EXCEPTION_MAPPING.items():
-            mock_request_method("get", {}, status_code)
+            mock_request_method("get", "{}", status_code)
 
             with pytest.raises(exception):
                 request_helper.request("bad_place")
@@ -42,7 +43,7 @@ class TestRequestHelper(object):
         for status_code, exception in STATUS_CODE_TO_EXCEPTION_MAPPING.items():
             mock_request_method(
                 "get",
-                {"message": response_message,},
+                json.dumps({"message": response_message,}),
                 status_code,
                 headers={"X-Request-ID": request_id},
             )
@@ -75,7 +76,8 @@ class TestRequestHelper(object):
             assert ex.__class__ == ServerException
 
     def test_request_includes_base_headers(self, capture_and_mock_request):
-        request_args, request_kwargs = capture_and_mock_request("get", {}, 200)
+        request_args, request_kwargs = capture_and_mock_request(
+            "get", "{}", 200)
 
         RequestHelper().request("ok_place")
 

--- a/workos/utils/request.py
+++ b/workos/utils/request.py
@@ -67,10 +67,11 @@ class RequestHelper(object):
             response = request_fn(url, headers=headers, json=params)
 
         response_json = None
-        try:
-            response_json = response.json()
-        except ValueError:
-            raise ServerException(response)
+        if response.headers.get("content-type", "").startswith("application/json"):
+            try:
+                response_json = response.json()
+            except ValueError:
+                raise ServerException(response)
 
         status_code = response.status_code
         if status_code >= 400 and status_code < 500:


### PR DESCRIPTION
The connection and organization DELETE endpoints don't return JSON so a `ServerException` is raised on successful operations. (I don't know if this is the case for `DELETE directories/:id` as I have nothing to test against.) 

To reproduce the error with tests I updated the `MockResponse` to deserialize the provided response and updated all tests which used it to provide a serialized string.

To fix the issue this checks the Content-Type header to see if it's JSON before trying to deserialize the response. 

Exception:
```
Traceback (most recent call last):
  <snip>
  File "/app/utils/accounts.py", line 1008, in delete
    sso.workos_client.organizations.delete_organization(
  File "/usr/local/lib/python3.8/site-packages/workos/organizations.py", line 112, in delete_organization
    return self.request_helper.request(
  File "/usr/local/lib/python3.8/site-packages/workos/utils/request.py", line 80, in request
    raise ServerException(response)
workos.exceptions.ServerException: (message=No message, request_id=f801bae5-f482-42fa-96c1-a44c5592d1ee)
```

```
DELETE https://api.workos.com/organizations/org_1a2b3c4d
----------
response.headers:
{'Access-Control-Allow-Credentials': 'true',
 'Connection': 'keep-alive',
 'Content-Length': '8',
 'Content-Security-Policy': "default-src 'self';base-uri "
                            "'self';block-all-mixed-content;font-src 'self' "
                            "https: data:;frame-ancestors 'self';img-src "
                            "'self' data:;object-src 'none';script-src "
                            "'self';script-src-attr 'none';style-src 'self' "
                            "https: 'unsafe-inline';upgrade-insecure-requests",
 'Content-Type': 'text/plain; charset=utf-8',
 'Date': 'Wed, 16 Jun 2021 20:08:59 GMT',
 'Etag': 'W/"8-YaBXLEiT7zQxEyDYTILfiL6oPhE"',
 'Expect-Ct': 'max-age=0',
 'Referrer-Policy': 'no-referrer',
 'Server': 'Cowboy',
 'Strict-Transport-Security': 'max-age=15552000; includeSubDomains',
 'Vary': 'Origin, Accept-Encoding',
 'Via': '1.1 vegur',
 'X-Content-Type-Options': 'nosniff',
 'X-Dns-Prefetch-Control': 'off',
 'X-Download-Options': 'noopen',
 'X-Frame-Options': 'SAMEORIGIN',
 'X-Permitted-Cross-Domain-Policies': 'none',
 'X-Request-Id': 'f801bae5-f482-42fa-96c1-a44c5592d1ee',
 'X-Xss-Protection': '0'}

response.content:
b'Accepted'
```

```
DELETE https://api.workos.com/connections/conn_1a2b3c4d
----------
response.headers:
'Access-Control-Allow-Credentials': 'true',
 'Connection': 'keep-alive',
 'Content-Length': '0',
 'Content-Security-Policy': "default-src 'self';base-uri "
                            "'self';block-all-mixed-content;font-src 'self' "
                            "https: data:;frame-ancestors 'self';img-src "
                            "'self' data:;object-src 'none';script-src "
                            "'self';script-src-attr 'none';style-src 'self' "
                            "https: 'unsafe-inline';upgrade-insecure-requests",
 'Date': 'Wed, 16 Jun 2021 20:01:58 GMT',
 'Etag': 'W/"a-bAsFyilMr4Ra1hIU5PyoyFRunpI"',
 'Expect-Ct': 'max-age=0',
 'Referrer-Policy': 'no-referrer',
 'Server': 'Cowboy',
 'Strict-Transport-Security': 'max-age=15552000; includeSubDomains',
 'Vary': 'Origin',
 'Via': '1.1 vegur',
 'X-Content-Type-Options': 'nosniff',
 'X-Dns-Prefetch-Control': 'off',
 'X-Download-Options': 'noopen',
 'X-Frame-Options': 'SAMEORIGIN',
 'X-Permitted-Cross-Domain-Policies': 'none',
 'X-Request-Id': '09354bd9-73f1-44be-a815-eda074f2a833',
 'X-Xss-Protection': '0'}

response.content:
b''
```