### PR TITLE
Add OrganizationId to Directory tests

### DIFF
--- a/tests/test_directory_sync.py
+++ b/tests/test_directory_sync.py
@@ -105,6 +105,7 @@ class TestDirectorySync(object):
                     "type": "gsuite directory",
                     "name": "Ri Jeong Hyeok",
                     "environment_id": "environment_id",
+                    "organization_id": "organization_id",
                     "domain": "crashlandingonyou.com",
                 }
             ],


### PR DESCRIPTION
https://linear.app/workos/issue/SDK-218/add-organizationid-to-directory-endpoint-python-sdk

No need to add `organization_id` to the Directory endpoint for Python, but updating relevant Directory Sync tests.