### PR TITLE
Clean up test mocking

### DIFF
--- a/tests/test_audit_trail.py
+++ b/tests/test_audit_trail.py
@@ -26,12 +26,10 @@ class TestAuditTrail(object):
             "occurred_at": datetime.now().isoformat(),
             "metadata": {"a": "b"},
         }
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_request_method("post", mock_response, 200)
+        mock_request_method("post", {"success": True}, 200)
 
-        result = self.audit_trail.create_event(event)
-        assert result == True
+        response = self.audit_trail.create_event(event)
+        assert response == True
 
     def test_create_audit_trail_event_fails_with_long_metadata(self):
         with pytest.raises(ValueError, match=r"Number of metadata keys exceeds .*"):

--- a/tests/test_directory_sync.py
+++ b/tests/test_directory_sync.py
@@ -114,40 +114,56 @@ class TestDirectorySync(object):
 
     def test_list_users_with_directory(self, mock_users, mock_request_method):
         mock_request_method("get", mock_users, 200)
+
         users = self.directory_sync.list_users(directory="directory_id")
+
         assert users == mock_users
 
     def test_list_users_with_group(self, mock_users, mock_request_method):
         mock_request_method("get", mock_users, 200)
+
         users = self.directory_sync.list_users(group="directory_grp_id")
+
         assert users == mock_users
 
     def test_list_groups_with_directory(self, mock_groups, mock_request_method):
         mock_request_method("get", mock_groups, 200)
+
         groups = self.directory_sync.list_groups(directory="directory_id")
+
         assert groups == mock_groups
 
     def test_list_groups_with_user(self, mock_groups, mock_request_method):
         mock_request_method("get", mock_groups, 200)
+
         groups = self.directory_sync.list_groups(user="directory_usr_id")
+
         assert groups == mock_groups
 
     def test_get_user(self, mock_user, mock_request_method):
         mock_request_method("get", mock_user, 200)
+
         user = self.directory_sync.get_user(user="directory_usr_id")
+
         assert user == mock_user
 
     def test_get_group(self, mock_group, mock_request_method):
         mock_request_method("get", mock_group, 200)
+
         group = self.directory_sync.get_group(group="directory_grp_id")
+
         assert group == mock_group
 
     def test_list_directories(self, mock_directories, mock_request_method):
         mock_request_method("get", mock_directories, 200)
+
         directories = self.directory_sync.list_directories()
+
         assert directories == mock_directories
 
     def test_delete_directory(self, mock_directories, mock_request_method):
         mock_request_method("delete", None, 202)
+
         response = self.directory_sync.delete_directory(directory="directory_id")
+
         assert response is None

--- a/tests/test_directory_sync.py
+++ b/tests/test_directory_sync.py
@@ -113,71 +113,41 @@ class TestDirectorySync(object):
         }
 
     def test_list_users_with_directory(self, mock_users, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_users
-        mock_request_method("get", mock_response, 200)
-        response = self.directory_sync.list_users(directory="directory_id")
-        assert response.status_code == 200
-        assert response.response_dict == mock_users
+        mock_request_method("get", mock_users, 200)
+        users = self.directory_sync.list_users(directory="directory_id")
+        assert users == mock_users
 
     def test_list_users_with_group(self, mock_users, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_users
-        mock_request_method("get", mock_response, 200)
-        response = self.directory_sync.list_users(group="directory_grp_id")
-        assert response.status_code == 200
-        assert response.response_dict == mock_users
+        mock_request_method("get", mock_users, 200)
+        users = self.directory_sync.list_users(group="directory_grp_id")
+        assert users == mock_users
 
     def test_list_groups_with_directory(self, mock_groups, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_groups
-        mock_request_method("get", mock_response, 200)
-        response = self.directory_sync.list_groups(directory="directory_id")
-        assert response.status_code == 200
-        assert response.response_dict == mock_groups
+        mock_request_method("get", mock_groups, 200)
+        groups = self.directory_sync.list_groups(directory="directory_id")
+        assert groups == mock_groups
 
     def test_list_groups_with_user(self, mock_groups, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_groups
-        mock_request_method("get", mock_response, 200)
-        response = self.directory_sync.list_groups(user="directory_usr_id")
-        assert response.status_code == 200
-        assert response.response_dict == mock_groups
+        mock_request_method("get", mock_groups, 200)
+        groups = self.directory_sync.list_groups(user="directory_usr_id")
+        assert groups == mock_groups
 
     def test_get_user(self, mock_user, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_user
-        mock_request_method("get", mock_response, 200)
-        response = self.directory_sync.get_user(user="directory_usr_id")
-        assert response.status_code == 200
-        assert response.response_dict == mock_user
+        mock_request_method("get", mock_user, 200)
+        user = self.directory_sync.get_user(user="directory_usr_id")
+        assert user == mock_user
 
     def test_get_group(self, mock_group, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_group
-        mock_request_method("get", mock_response, 200)
-        response = self.directory_sync.get_group(group="directory_grp_id")
-        assert response.status_code == 200
-        assert response.response_dict == mock_group
+        mock_request_method("get", mock_group, 200)
+        group = self.directory_sync.get_group(group="directory_grp_id")
+        assert group == mock_group
 
     def test_list_directories(self, mock_directories, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_directories
-        mock_request_method("get", mock_response, 200)
-        response = self.directory_sync.list_directories()
-        assert response.status_code == 200
-        assert response.response_dict == mock_directories
+        mock_request_method("get", mock_directories, 200)
+        directories = self.directory_sync.list_directories()
+        assert directories == mock_directories
 
     def test_delete_directory(self, mock_directories, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 202
-        mock_request_method("delete", mock_response, 202)
+        mock_request_method("delete", None, 202)
         response = self.directory_sync.delete_directory(directory="directory_id")
-        assert response.status_code == 202
+        assert response is None

--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -76,52 +76,40 @@ class TestOrganizations(object):
         }
 
     def test_list_organizations(self, mock_organizations, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_organizations
-        mock_request_method("get", mock_response, 200)
-        response = self.organizations.list_organizations()
-        assert response.status_code == 200
-        assert len(response.response_dict["data"]) == 2
+        mock_request_method("get", {"data": mock_organizations}, 200)
+
+        organizations_response = self.organizations.list_organizations()
+
+        assert organizations_response["data"] == mock_organizations
 
     def test_get_organization(self, mock_organization, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_organization
-        mock_request_method("get", mock_response, 200)
-        response = self.organizations.get_organization(organization="organization_id")
-        assert response.status_code == 200
-        assert response.response_dict == mock_organization
+        mock_request_method("get", mock_organization, 200)
+
+        organization = self.organizations.get_organization(organization="organization_id")
+
+        assert organization == mock_organization
 
     def test_create_organization(self, mock_organization, mock_request_method):
-        organization = {"domains": ["example.com"], "name": "Test Organization"}
-        mock_response = Response()
-        mock_response.status_code = 201
-        mock_response.response_dict = mock_organization
-        mock_request_method("post", mock_response, 201)
+        mock_request_method("post", mock_organization, 201)
 
-        result = self.organizations.create_organization(organization)
-        subject = result.response_dict
+        payload = {"domains": ["example.com"], "name": "Test Organization"}
+        organization = self.organizations.create_organization(payload)
 
-        assert subject["id"] == "org_01EHT88Z8J8795GZNQ4ZP1J81T"
-        assert subject["name"] == "Test Organization"
+        assert organization["id"] == "org_01EHT88Z8J8795GZNQ4ZP1J81T"
+        assert organization["name"] == "Test Organization"
 
     def test_update_organization(self, mock_organization_updated, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 201
-        mock_response.response_dict = mock_organization_updated
-        mock_request_method("put", mock_response, 201)
+        mock_request_method("put", mock_organization_updated, 201)
 
-        result = self.organizations.update_organization(
+        updated_organization = self.organizations.update_organization(
             organization="org_01EHT88Z8J8795GZNQ4ZP1J81T",
             name="Example Organization",
             domains=["example.io"],
         )
-        subject = result.response_dict
 
-        assert subject["id"] == "org_01EHT88Z8J8795GZNQ4ZP1J81T"
-        assert subject["name"] == "Example Organization"
-        assert subject["domains"] == [
+        assert updated_organization["id"] == "org_01EHT88Z8J8795GZNQ4ZP1J81T"
+        assert updated_organization["name"] == "Example Organization"
+        assert updated_organization["domains"] == [
             {
                 "domain": "example.io",
                 "object": "organization_domain",
@@ -130,8 +118,8 @@ class TestOrganizations(object):
         ]
 
     def test_delete_organization(self, setup, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 204
-        mock_request_method("delete", mock_response, 204)
+        mock_request_method("delete", None, 202)
+
         response = self.organizations.delete_organization(organization="connection_id")
-        assert response.status_code == 204
+
+        assert response is None

--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -85,7 +85,9 @@ class TestOrganizations(object):
     def test_get_organization(self, mock_organization, mock_request_method):
         mock_request_method("get", mock_organization, 200)
 
-        organization = self.organizations.get_organization(organization="organization_id")
+        organization = self.organizations.get_organization(
+            organization="organization_id"
+        )
 
         assert organization == mock_organization
 

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -25,19 +25,15 @@ class TestPasswordless(object):
     def test_create_session_succeeds(
         self, mock_passwordless_session, mock_request_method
     ):
-        mock_response = Response()
-        mock_response.status_code = 201
-        mock_response.response_dict = mock_passwordless_session
-        mock_request_method("post", mock_response, 201)
+        mock_request_method("post", mock_passwordless_session, 201)
 
         session_options = {
             "email": "demo@workos-okta.com",
             "type": "MagicLink",
         }
-        response = self.passwordless.create_session(session_options)
+        passwordless_session = self.passwordless.create_session(session_options)
 
-        assert response.status_code == 201
-        assert response.response_dict == mock_passwordless_session
+        assert passwordless_session == mock_passwordless_session
 
     def test_get_send_session_succeeds(self, mock_request_method):
         response = {
@@ -48,4 +44,5 @@ class TestPasswordless(object):
         response = self.passwordless.send_session(
             "passwordless_session_01EHDAK2BFGWCSZXP9HGZ3VK8C"
         )
+
         assert response == True

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -17,23 +17,15 @@ class TestPortal(object):
         return {"link": "https://id.workos.com/portal/launch?secret=secret"}
 
     def test_generate_link_sso(self, mock_portal_link, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 201
-        mock_response.response_dict = mock_portal_link
-        mock_request_method("post", mock_response, 201)
+        mock_request_method("post", mock_portal_link, 201)
 
-        result = self.portal.generate_link("sso", "org_01EHQMYV6MBK39QC5PZXHY59C3")
-        subject = result.response_dict
+        response = self.portal.generate_link("sso", "org_01EHQMYV6MBK39QC5PZXHY59C3")
 
-        assert subject["link"] == "https://id.workos.com/portal/launch?secret=secret"
+        assert response["link"] == "https://id.workos.com/portal/launch?secret=secret"
 
     def test_generate_link_dsync(self, mock_portal_link, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 201
-        mock_response.response_dict = mock_portal_link
-        mock_request_method("post", mock_response, 201)
+        mock_request_method("post", mock_portal_link, 201)
 
-        result = self.portal.generate_link("dsync", "org_01EHQMYV6MBK39QC5PZXHY59C3")
-        subject = result.response_dict
+        response = self.portal.generate_link("dsync", "org_01EHQMYV6MBK39QC5PZXHY59C3")
 
-        assert subject["link"] == "https://id.workos.com/portal/launch?secret=secret"
+        assert response["link"] == "https://id.workos.com/portal/launch?secret=secret"

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -217,28 +217,24 @@ class TestSSO(object):
     def test_get_connection(
         self, setup_with_client_id, mock_connection, mock_request_method
     ):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_connection
-        mock_request_method("get", mock_response, 200)
-        response = self.sso.get_connection(connection="connection_id")
-        assert response.status_code == 200
-        assert response.response_dict == mock_connection
+        mock_request_method("get", mock_connection, 200)
+
+        connection = self.sso.get_connection(connection="connection_id")
+
+        assert connection == mock_connection
 
     def test_list_connections(
         self, setup_with_client_id, mock_connections, mock_request_method
     ):
-        mock_response = Response()
-        mock_response.status_code = 200
-        mock_response.response_dict = mock_connections
-        mock_request_method("get", mock_response, 200)
-        response = self.sso.list_connections()
-        assert response.status_code == 200
-        assert response.response_dict == mock_connections
+        mock_request_method("get", mock_connections, 200)
+
+        connections_response = self.sso.list_connections()
+
+        assert connections_response["data"] == mock_connections["data"]
 
     def test_delete_connection(self, setup_with_client_id, mock_request_method):
-        mock_response = Response()
-        mock_response.status_code = 204
-        mock_request_method("delete", mock_response, 204)
+        mock_request_method("delete", None, 204)
+
         response = self.sso.delete_connection(connection="connection_id")
-        assert response.status_code == 204
+
+        assert response is None

--- a/workos/audit_trail.py
+++ b/workos/audit_trail.py
@@ -61,7 +61,7 @@ class AuditTrail(object):
             "idempotency-key": idempotency_key,
         }
 
-        self.request_helper.request(
+        response = self.request_helper.request(
             EVENTS_PATH,
             method=REQUEST_METHOD_POST,
             params=event,
@@ -69,7 +69,7 @@ class AuditTrail(object):
             token=workos.api_key,
         )
 
-        return True
+        return response["success"]
 
     def get_events(
         self,


### PR DESCRIPTION
This PR begins the process of cleaning up the mocks in our tests.

Previously we were double mocking our response objects, which was simulating a response object being returned from the WorkOS API, which is not correct.