### PR TITLE
Only attempt to parse JSON for JSON responses

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,18 @@ class MockResponse(object):
         self.status_code = status_code
         self.headers = {} if headers is None else headers
 
+        if "content-type" not in self.headers:
+            self.headers["content-type"] = "application/json"
+
     def json(self):
         return self.response_dict
+
+
+class MockRawResponse(object):
+    def __init__(self, content, status_code, headers=None):
+        self.content = content
+        self.status_code = status_code
+        self.headers = {} if headers is None else headers
 
 
 @pytest.fixture
@@ -34,6 +44,17 @@ def mock_request_method(monkeypatch):
     def inner(method, response_dict, status_code, headers=None):
         def mock(*args, **kwargs):
             return MockResponse(response_dict, status_code, headers=headers)
+
+        monkeypatch.setattr(requests, method, mock)
+
+    return inner
+
+
+@pytest.fixture
+def mock_raw_request_method(monkeypatch):
+    def inner(method, content, status_code, headers=None):
+        def mock(*args, **kwargs):
+            return MockRawResponse(content, status_code, headers=headers)
 
         monkeypatch.setattr(requests, method, mock)
 

--- a/tests/test_directory_sync.py
+++ b/tests/test_directory_sync.py
@@ -161,8 +161,13 @@ class TestDirectorySync(object):
 
         assert directories == mock_directories
 
-    def test_delete_directory(self, mock_directories, mock_request_method):
-        mock_request_method("delete", None, 202)
+    def test_delete_directory(self, mock_directories, mock_raw_request_method):
+        mock_raw_request_method(
+            "delete",
+            "Accepted",
+            202,
+            headers={"content-type": "text/plain; charset=utf-8"},
+        )
 
         response = self.directory_sync.delete_directory(directory="directory_id")
 

--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -119,8 +119,13 @@ class TestOrganizations(object):
             }
         ]
 
-    def test_delete_organization(self, setup, mock_request_method):
-        mock_request_method("delete", None, 202)
+    def test_delete_organization(self, setup, mock_raw_request_method):
+        mock_raw_request_method(
+            "delete",
+            "Accepted",
+            202,
+            headers={"content-type": "text/plain; charset=utf-8"},
+        )
 
         response = self.organizations.delete_organization(organization="connection_id")
 

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -232,8 +232,13 @@ class TestSSO(object):
 
         assert connections_response["data"] == mock_connections["data"]
 
-    def test_delete_connection(self, setup_with_client_id, mock_request_method):
-        mock_request_method("delete", None, 204)
+    def test_delete_connection(self, setup_with_client_id, mock_raw_request_method):
+        mock_raw_request_method(
+            "delete",
+            "No Content",
+            204,
+            headers={"content-type": "text/plain; charset=utf-8"},
+        )
 
         response = self.sso.delete_connection(connection="connection_id")
 

--- a/workos/utils/request.py
+++ b/workos/utils/request.py
@@ -67,10 +67,16 @@ class RequestHelper(object):
             response = request_fn(url, headers=headers, json=params)
 
         response_json = None
-        try:
-            response_json = response.json()
-        except ValueError:
-            raise ServerException(response)
+        content_type = (
+            response.headers.get("content-type")
+            if response.headers is not None
+            else None
+        )
+        if content_type == "application/json":
+            try:
+                response_json = response.json()
+            except ValueError:
+                raise ServerException(response)
 
         status_code = response.status_code
         if status_code >= 400 and status_code < 500:


### PR DESCRIPTION
This PR fixes an issue where we were trying to parse the response body as JSON for API responses that did not return JSON.

We now only parse the response body as JSON if it has a `Content-Type` of `application/json`.

Closes #80.