### PR TITLE
Handle `Content-Type` headers that contain an encoding

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ class MockResponse(object):
         self.headers = {} if headers is None else headers
 
         if "content-type" not in self.headers:
-            self.headers["content-type"] = "application/json; charset=utf-8"
+            self.headers["content-type"] = "application/json"
 
     def json(self):
         return self.response_dict

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ class MockResponse(object):
         self.headers = {} if headers is None else headers
 
         if "content-type" not in self.headers:
-            self.headers["content-type"] = "application/json"
+            self.headers["content-type"] = "application/json; charset=utf-8"
 
     def json(self):
         return self.response_dict

--- a/tests/utils/test_requests.py
+++ b/tests/utils/test_requests.py
@@ -109,3 +109,20 @@ class TestRequestHelper(object):
         headers = set(request_kwargs["headers"].items())
 
         assert base_headers.issubset(headers)
+
+    def test_request_parses_json_when_content_type_present(self, mock_request_method):
+        mock_request_method(
+            "get", {"foo": "bar"}, 200, headers={"content-type": "application/json"}
+        )
+
+        assert RequestHelper().request("ok_place") == {"foo": "bar"}
+
+    def test_request_parses_json_when_encoding_in_content_type(self, mock_request_method):
+        mock_request_method(
+            "get",
+            {"foo": "bar"},
+            200,
+            headers={"content-type": "application/json; charset=utf8"}
+        )
+
+        assert RequestHelper().request("ok_place") == {"foo": "bar"}

--- a/tests/utils/test_requests.py
+++ b/tests/utils/test_requests.py
@@ -117,12 +117,14 @@ class TestRequestHelper(object):
 
         assert RequestHelper().request("ok_place") == {"foo": "bar"}
 
-    def test_request_parses_json_when_encoding_in_content_type(self, mock_request_method):
+    def test_request_parses_json_when_encoding_in_content_type(
+        self, mock_request_method
+    ):
         mock_request_method(
             "get",
             {"foo": "bar"},
             200,
-            headers={"content-type": "application/json; charset=utf8"}
+            headers={"content-type": "application/json; charset=utf8"},
         )
 
         assert RequestHelper().request("ok_place") == {"foo": "bar"}

--- a/workos/utils/request.py
+++ b/workos/utils/request.py
@@ -72,7 +72,7 @@ class RequestHelper(object):
             if response.headers is not None
             else None
         )
-        if content_type == "application/json":
+        if content_type is not None and "application/json" in content_type:
             try:
                 response_json = response.json()
             except ValueError:


### PR DESCRIPTION
The [`Content-Type`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) header is frequently sent like `application/json`, [but it can also contain extra "subtypes" like `; charset=utf8`](https://www.w3.org/Protocols/rfc1341/4_Content-Type.html). This leads to an issue with our response handling, as it compares the entire header value (like `application/json; charset=urf8`) against `application/json` to determine if the response was JSON.

These changes make that check less exact, and instead we only look to see if the header contains `application/json`, and then attempt to deserialize JSON.