### PR TITLE
Add support for `organization` parameter

### DIFF
--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -18,6 +18,7 @@ class TestSSO(object):
         self.redirect_uri = "https://localhost/auth/callback"
         self.state = json.dumps({"things": "with_stuff"})
         self.connection = "connection_123"
+        self.organization = "organization_123"
 
         self.sso = SSO()
 
@@ -173,6 +174,25 @@ class TestSSO(object):
 
         assert dict(parse_qsl(parsed_url.query)) == {
             "connection": self.connection,
+            "client_id": workos.client_id,
+            "redirect_uri": self.redirect_uri,
+            "response_type": RESPONSE_TYPE_CODE,
+            "state": self.state,
+        }
+
+    def test_authorization_url_has_expected_query_params_with_organization(
+        self, setup_with_client_id
+    ):
+        authorization_url = self.sso.get_authorization_url(
+            organization=self.organization,
+            redirect_uri=self.redirect_uri,
+            state=self.state,
+        )
+
+        parsed_url = urlparse(authorization_url)
+
+        assert dict(parse_qsl(parsed_url.query)) == {
+            "organization": self.organization,
             "client_id": workos.client_id,
             "redirect_uri": self.redirect_uri,
             "response_type": RESPONSE_TYPE_CODE,

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -39,7 +39,13 @@ class SSO(object):
         return self._request_helper
 
     def get_authorization_url(
-        self, domain=None, redirect_uri=None, state=None, provider=None, connection=None
+        self,
+        domain=None,
+        redirect_uri=None,
+        state=None,
+        provider=None,
+        connection=None,
+        organization=None,
     ):
         """Generate an OAuth 2.0 authorization URL.
 
@@ -53,6 +59,7 @@ class SSO(object):
             back as a query parameter
             provider (ConnectionType) - Authentication service provider descriptor
             connection (string) - Unique identifier for a WorkOS Connection
+            organization (string) - Unique identifier for a WorkOS Organization
 
         Returns:
             str: URL to redirect a User to to begin the OAuth workflow with WorkOS
@@ -63,18 +70,29 @@ class SSO(object):
             "response_type": RESPONSE_TYPE_CODE,
         }
 
-        if domain is None and provider is None and connection is None:
+        if (
+            domain is None
+            and provider is None
+            and connection is None
+            and organization is None
+        ):
             raise ValueError(
-                "Incomplete arguments. Need to specify either a 'connection', 'domain' or 'provider'"
+                "Incomplete arguments. Need to specify either a 'connection', 'organization', 'domain', or 'provider'"
             )
         if provider is not None:
             if not isinstance(provider, ConnectionType):
                 raise ValueError("'provider' must be of type ConnectionType")
             params["provider"] = str(provider.value)
         if domain is not None:
+            warn(
+                "The 'domain' parameter for 'get_authorization_url' is deprecated. Please use 'organization' instead.",
+                DeprecationWarning,
+            )
             params["domain"] = domain
         if connection is not None:
             params["connection"] = connection
+        if organization is not None:
+            params["organization"] = organization
 
         if state is not None:
             params["state"] = state


### PR DESCRIPTION
This PR adds support for the `organization` parameter to initiate SSO.

As part of this, the `domain` parameter has also been deprecated in favor of `organization`.

Resolves SDK-356.