### PR TITLE
Create a requirement for RedirectURI in GetAuthorizationURL function

### DIFF
--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -126,6 +126,18 @@ class TestSSO(object):
                 provider="foo", redirect_uri=self.redirect_uri, state=self.state
             )
 
+    def test_authorization_url_throws_value_error_wihout_redirect_uri(
+        self, setup_with_client_id
+    ):
+        with pytest.raises(
+            ValueError, match="Incomplete arguments. Need to specify a 'redirect_uri'."
+        ):
+            self.sso.get_authorization_url(
+                connection=self.connection,
+                login_hint=self.login_hint,
+                state=self.state,
+            )
+
     def test_authorization_url_has_expected_query_params_with_provider(
         self, setup_with_client_id
     ):

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -102,12 +102,10 @@ class SSO(object):
 
         if state is not None:
             params["state"] = state
-        
+
         if redirect_uri is None:
-            raise ValueError(
-               "Incomplete arguments. Need to specify a Redirect URI"
-            )
-            
+            raise ValueError("Incomplete arguments. Need to specify a Redirect URI")
+
         prepared_request = Request(
             "GET",
             self.request_helper.generate_api_url(AUTHORIZATION_PATH),

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -104,7 +104,7 @@ class SSO(object):
             params["state"] = state
 
         if redirect_uri is None:
-            raise ValueError("Incomplete arguments. Need to specify a Redirect URI")
+            raise ValueError("Incomplete arguments. Need to specify a 'redirect_uri'.")
 
         prepared_request = Request(
             "GET",

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -102,7 +102,12 @@ class SSO(object):
 
         if state is not None:
             params["state"] = state
-
+        
+        if redirect_uri is None:
+            raise ValueError(
+               "Incomplete arguments. Need to specify a Redirect URI"
+            )
+            
         prepared_request = Request(
             "GET",
             self.request_helper.generate_api_url(AUTHORIZATION_PATH),


### PR DESCRIPTION
Currently if customers don't provide a redirectURI in the getAuthorizationURI function they do not get an error from the SDK, but will receive an error in the browser. We can improve the user experience by raising this error in the SDK instead of the browser. 