### PR TITLE
Add error if connection_type is not string

### DIFF
--- a/workos/sso.py
+++ b/workos/sso.py
@@ -204,8 +204,10 @@ class SSO(object):
         }
 
          if connection_type is not None:
-            if isinstance(connection_type, ConnectionType):
+             if isinstance(connection_type, ConnectionType):
                 raise ValueError("'connection_type' must be of type string")
+            else: 
+                raise ValueError("'connection_type' is not a valid connection type")
             params["connection_type"] = connection_type
 
         return self.request_helper.request(

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -204,7 +204,7 @@ class SSO(object):
         }
 
          if connection_type is not None:
-             if isinstance(connection_type, ConnectionType):
+            if isinstance(connection_type, ConnectionType):
                 raise ValueError("'connection_type' must be of type string")
             params["connection_type"] = connection_type
 

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -202,6 +202,12 @@ class SSO(object):
             "before": before,
             "after": after,
         }
+
+         if connection_type is not None:
+            if isinstance(connection_type, ConnectionType):
+                raise ValueError("'connection_type' must be of type string")
+            params["connection_type"] = connection_type
+
         return self.request_helper.request(
             "connections",
             method=REQUEST_METHOD_GET,

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -203,7 +203,7 @@ class SSO(object):
             "after": after,
         }
 
-         if connection_type is not None:
+        if connection_type is not None:
             if isinstance(connection_type, ConnectionType):
                 raise ValueError("'connection_type' must be of type string")
             params["connection_type"] = connection_type

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -206,8 +206,6 @@ class SSO(object):
          if connection_type is not None:
              if isinstance(connection_type, ConnectionType):
                 raise ValueError("'connection_type' must be of type string")
-            else: 
-                raise ValueError("'connection_type' is not a valid connection type")
             params["connection_type"] = connection_type
 
         return self.request_helper.request(


### PR DESCRIPTION
This is in response to the issue raised here: 
https://github.com/workos-inc/workos-python/issues/110

From Marshall: 
> I think we should be safe to add a runtime error if the user passes a string value that does not cast to an enum value, it's fairly safe to assume that moving this validation up into the SDK won't break any existing callers.

This change throws an error if the passed `connection_type` is of `ConnectionType` type rather than string (which the current behavior requires)

FWIW, I'm not strictly certain that this actually requires:  `params["connection_type"] = connection_type` as this is already occurring.