### PR TITLE
Make `connection_type` for `list_connections` accept enum values

### DIFF
--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -354,6 +354,42 @@ class TestSSO(object):
 
         assert connections_response["data"] == mock_connections["data"]
 
+    def test_list_connections_with_connection_type_as_invalid_string(
+        self, setup_with_client_id, mock_connections, mock_request_method
+    ):
+        mock_request_method("get", mock_connections, 200)
+
+        try:
+            self.sso.list_connections(connection_type="UnknownSAML")
+        except Exception as ex:
+            assert str(ex) == "'connection_type' must be a member of ConnectionType"
+
+    def test_list_connections_with_connection_type_as_string(
+        self, setup_with_client_id, mock_connections, capture_and_mock_request
+    ):
+        request_args, request_kwargs = capture_and_mock_request(
+            "get", mock_connections, 200
+        )
+
+        connections_response = self.sso.list_connections(connection_type="GenericSAML")
+
+        request_params = request_kwargs["params"]
+        assert request_params["connection_type"] == "GenericSAML"
+
+    def test_list_connections_with_connection_type_as_enum(
+        self, setup_with_client_id, mock_connections, capture_and_mock_request
+    ):
+        request_args, request_kwargs = capture_and_mock_request(
+            "get", mock_connections, 200
+        )
+
+        connections_response = self.sso.list_connections(
+            connection_type=ConnectionType.OktaSAML
+        )
+
+        request_params = request_kwargs["params"]
+        assert request_params["connection_type"] == "OktaSAML"
+
     def test_delete_connection(self, setup_with_client_id, mock_raw_request_method):
         mock_raw_request_method(
             "delete",

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -359,10 +359,10 @@ class TestSSO(object):
     ):
         mock_request_method("get", mock_connections, 200)
 
-        try:
+        with pytest.raises(
+            ValueError, match="'connection_type' must be a member of ConnectionType"
+        ):
             self.sso.list_connections(connection_type="UnknownSAML")
-        except Exception as ex:
-            assert str(ex) == "'connection_type' must be a member of ConnectionType"
 
     def test_list_connections_with_connection_type_as_string(
         self, setup_with_client_id, mock_connections, capture_and_mock_request

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -203,6 +203,11 @@ class SSO(object):
         if connection_type is not None and isinstance(connection_type, str):
             try:
                 connection_type = ConnectionType[connection_type]
+
+                warn(
+                    "Passing a string value as the 'connection_type' parameter for 'list_connections' is deprecated and will be removed in the next major version. Please pass a 'ConnectionType' instead.",
+                    DeprecationWarning,
+                )
             except KeyError:
                 raise ValueError("'connection_type' must be a member of ConnectionType")
 

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -194,8 +194,19 @@ class SSO(object):
         Returns:
             dict: Connections response from WorkOS.
         """
+
+        # This method used to accept `connection_type` as a string, so we try
+        # to convert strings to a `ConnectionType` to support existing callers.
+        if connection_type is not None and isinstance(connection_type, str):
+            try:
+                connection_type = ConnectionType[connection_type]
+            except KeyError:
+                raise ValueError("'connection_type' must be a member of ConnectionType")
+
         params = {
-            "connection_type": connection_type,
+            "connection_type": (
+                connection_type.value if connection_type is not None else None
+            ),
             "domain": domain,
             "organization_id": organization_id,
             "limit": limit,

--- a/workos/sso.py
+++ b/workos/sso.py
@@ -197,6 +197,9 @@ class SSO(object):
 
         # This method used to accept `connection_type` as a string, so we try
         # to convert strings to a `ConnectionType` to support existing callers.
+        #
+        # TODO: Remove support for string values of `ConnectionType` in the next
+        #       major version.
         if connection_type is not None and isinstance(connection_type, str):
             try:
                 connection_type = ConnectionType[connection_type]


### PR DESCRIPTION
This PR updates the handling of the `connection_type` parameter for the `sso.list_connections` method to support passing a `ConnectionType` enum value.

To retain backwards compatibility, we attempt to coerce any string values to their corresponding `ConnectionType` values. If given an invalid string, an exception will be thrown. This should not be a breaking change, as we already validate the connection types on the API side. All we're doing is moving the validation up into the SDK.

Fixes #110.

Closes #111.