### PR TITLE
v1.8.0

### DIFF
--- a/workos/__about__.py
+++ b/workos/__about__.py
@@ -12,7 +12,7 @@ __package_name__ = "workos"
 
 __package_url__ = "https://github.com/workos-inc/workos-python"
 
-__version__ = "1.7.0"
+__version__ = "1.8.0"
 
 __author__ = "WorkOS"
 


### PR DESCRIPTION
### Changed

- `get_authorization_url` now throws an exception when `redirect_uri` is not provided (#107)
  - This matches the upstream requirements of the WorkOS API
- `list_connections` now accepts a `ConnectionType` for the `connection_type` parameter (#112)
  - String values will continue to work, but are considered deprecated

### Deprecations

- Passing string values as the `connection_type` parameter for `list_connections` is deprecated (#112)